### PR TITLE
ZOB-361 Refresh boxes when switching entity pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a changelog for **ZachranObed** application.
 
 ### Fixed
 - **ZOB-352** Fix logout behavior on Web.
+- **ZOB-361** Refresh boxes when switching entity pair.
 
 ### Changed
 - **ZOB-313** Remove FCM token after user signs out.

--- a/lib/ui/screens/overview_screen.dart
+++ b/lib/ui/screens/overview_screen.dart
@@ -34,8 +34,8 @@ class _OverviewScreenState extends State<OverviewScreen> with LifecycleWatcher {
   FoodBoxesCheckupState _boxesCheckupState = FoodBoxesCheckupAllGood(isVerified: false);
 
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     _refreshBoxesCheckupState();
   }
 


### PR DESCRIPTION
# Description

* JIRA: https://etnetera.atlassian.net/browse/ZOB-361
* Explanation: `initState()` is called only once widget is initially built, but we do want to refresh boxes checkup state when there is a change in the ChangeNotifier (`UserNotifier`), thus we should use `didChangeDependencies()`, which is called when there is a change in the notifier (for example when entity pair is changed).