### PR TITLE
ZOB-399 Update delivery state enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This is a changelog for **ZachranObed** application.
 - **ZOB-392** Update monthly food boxes checkup flow with new design.
 - **ZOB-394** Update box delivery flow with new design.
 - **ZOB-395** Update meals delivery flow with new design.
+- **ZOB-399** Update delivery state enum.
 
 ### Removed
 - **ZOB-396** Remove old design components.

--- a/lib/app/presentation/widget/canteen_donation_status_card.dart
+++ b/lib/app/presentation/widget/canteen_donation_status_card.dart
@@ -10,8 +10,8 @@ import 'package:zachranobed/common/presentation/widget/button/ui_primary_button.
 import 'package:zachranobed/common/presentation/widget/button/ui_text_button.dart';
 import 'package:zachranobed/common/presentation/widget/donation/ui_donation_status_card.dart';
 import 'package:zachranobed/common/presentation/widget/donation/ui_donation_time_range_label.dart';
-import 'package:zachranobed/common/presentation/widget/progress/ui_progress_stepper.dart';
 import 'package:zachranobed/common/presentation/widget/graphics/ui_icon.dart';
+import 'package:zachranobed/common/presentation/widget/progress/ui_progress_stepper.dart';
 
 /// A status card widget displaying the current donation state for canteen users.
 ///
@@ -21,9 +21,10 @@ import 'package:zachranobed/common/presentation/widget/graphics/ui_icon.dart';
 ///
 /// Delivery states and their UI:
 /// - **prepared**: Shows countdown timer and "Accept" button
-/// - **accepted/offered**: Shows pickup time range and "Offer Food" button
+/// - **accepted/onWayToPickUp**: Shows pickup time range and "Offer Food" button
 /// - **inDelivery**: Shows delivery time range
 /// - **delivered**: Shows completion message
+/// - **done**: Shows completion message
 /// - **null/notUsed**: Shows "not a delivery day" message
 class CanteenDonationStatusCard extends StatelessWidget {
   /// The canteen user data containing pair information and pickup times.
@@ -94,7 +95,7 @@ class CanteenDonationStatusCard extends StatelessWidget {
       );
     }
 
-    if (delivery.state == DeliveryState.delivered) {
+    if (delivery.state == DeliveryState.delivered || delivery.state == DeliveryState.done) {
       return StyledText(
         text: context.l10n.overviewDonationStatusCardDoneLabel,
         style: context.textStyles.bodyMedium,
@@ -116,13 +117,16 @@ class CanteenDonationStatusCard extends StatelessWidget {
         statusText = context.l10n.overviewDonationStatusCardDeliveryDayLabel;
         break;
       case DeliveryState.accepted:
-      case DeliveryState.offered:
         statusText = context.l10n.overviewCanteenDonationStatusCardAcceptedLabel;
+        break;
+      case DeliveryState.onWayToPickUp:
+        statusText = context.l10n.overviewCanteenDonationStatusCardOnWayToPickUpLabel;
         break;
       case DeliveryState.inDelivery:
         statusText = context.l10n.overviewCanteenDonationStatusCardOnWayToCustomerLabel;
         break;
       case DeliveryState.delivered:
+      case DeliveryState.done:
       case DeliveryState.notUsed:
         // No-op, handled above
         break;
@@ -148,8 +152,11 @@ class CanteenDonationStatusCard extends StatelessWidget {
         isCurrentStepActive = true;
         break;
       case DeliveryState.accepted:
-      case DeliveryState.offered:
         currentStep = 1;
+        isCurrentStepActive = false;
+        break;
+      case DeliveryState.onWayToPickUp:
+        currentStep = 2;
         isCurrentStepActive = false;
         break;
       case DeliveryState.inDelivery:
@@ -157,6 +164,7 @@ class CanteenDonationStatusCard extends StatelessWidget {
         isCurrentStepActive = true;
         break;
       case DeliveryState.delivered:
+      case DeliveryState.done:
       case DeliveryState.notUsed:
         currentStep = 5;
         isCurrentStepActive = true;
@@ -166,7 +174,7 @@ class CanteenDonationStatusCard extends StatelessWidget {
     return UiProgressStepper(
       currentStep: currentStep,
       isCurrentStepActive: isCurrentStepActive,
-      isProgressComplete: delivery.state == DeliveryState.delivered,
+      isProgressComplete: delivery.state == DeliveryState.delivered || delivery.state == DeliveryState.done,
       icons: const [
         UiIconSpec.data(Icons.today_rounded),
         UiIconSpec.svg(ImageAssets.iconDeliveryAccept),
@@ -178,7 +186,10 @@ class CanteenDonationStatusCard extends StatelessWidget {
   }
 
   Widget? _buildActionInfo(BuildContext context, Delivery? delivery) {
-    if (delivery == null || !_canDonate(delivery) || delivery.state == DeliveryState.delivered) {
+    if (delivery == null ||
+        !_canDonate(delivery) ||
+        delivery.state == DeliveryState.delivered ||
+        delivery.state == DeliveryState.done) {
       return null;
     }
 
@@ -192,7 +203,7 @@ class CanteenDonationStatusCard extends StatelessWidget {
       );
     }
 
-    if (delivery.state == DeliveryState.accepted || delivery.state == DeliveryState.offered) {
+    if (delivery.state == DeliveryState.accepted || delivery.state == DeliveryState.onWayToPickUp) {
       return UiDonationTimeRangeLabel(
         label: context.l10n.overviewDonationStatusCardTimerPickUpLabel,
         startTime: TimeOfDay(
@@ -220,7 +231,10 @@ class CanteenDonationStatusCard extends StatelessWidget {
   }
 
   Widget? _buildActionButton(BuildContext context, Delivery? delivery) {
-    if (delivery == null || !_canDonate(delivery) || delivery.state == DeliveryState.delivered) {
+    if (delivery == null ||
+        !_canDonate(delivery) ||
+        delivery.state == DeliveryState.delivered ||
+        delivery.state == DeliveryState.done) {
       return null;
     }
 

--- a/lib/app/presentation/widget/charity_donation_status_card.dart
+++ b/lib/app/presentation/widget/charity_donation_status_card.dart
@@ -18,10 +18,11 @@ import 'package:zachranobed/common/presentation/widget/graphics/ui_icon.dart';
 ///
 /// Delivery states and their UI:
 /// - **prepared**: Shows "delivery day" message
-/// - **accepted/offered (no meals)**: Shows "accepted" message
-/// - **accepted/offered (with meals)**: Shows delivery time range and details button
+/// - **accepted/onWayToPickUp (no meals)**: Shows "accepted" message
+/// - **accepted/onWayToPickUp (with meals)**: Shows delivery time range and details button
 /// - **inDelivery**: Shows delivery time range and details button
 /// - **delivered**: Shows completion message
+/// - **done**: Shows completion message
 /// - **null/notUsed**: Shows "not a delivery day" message
 class CharityDonationStatusCard extends StatelessWidget {
   /// The charity user data containing pair information and delivery times.
@@ -80,7 +81,7 @@ class CharityDonationStatusCard extends StatelessWidget {
       );
     }
 
-    if (delivery.state == DeliveryState.delivered) {
+    if (delivery.state == DeliveryState.delivered || delivery.state == DeliveryState.done) {
       return StyledText(
         text: context.l10n.overviewDonationStatusCardDoneLabel,
         style: context.textStyles.bodyMedium,
@@ -102,7 +103,7 @@ class CharityDonationStatusCard extends StatelessWidget {
         statusText = context.l10n.overviewDonationStatusCardDeliveryDayLabel;
         break;
       case DeliveryState.accepted:
-      case DeliveryState.offered:
+      case DeliveryState.onWayToPickUp:
         if (!delivery.hasMeals) {
           statusText = context.l10n.overviewCharityDonationStatusCardAcceptedLabel;
         } else {
@@ -113,6 +114,7 @@ class CharityDonationStatusCard extends StatelessWidget {
         statusText = context.l10n.overviewCharityDonationStatusCardOnWayToCustomerLabel;
         break;
       case DeliveryState.delivered:
+      case DeliveryState.done:
       case DeliveryState.notUsed:
         // No-op, handled above
         break;
@@ -138,7 +140,7 @@ class CharityDonationStatusCard extends StatelessWidget {
         isCurrentStepActive = false;
         break;
       case DeliveryState.accepted:
-      case DeliveryState.offered:
+      case DeliveryState.onWayToPickUp:
         if (!delivery.hasMeals) {
           currentStep = 1;
           isCurrentStepActive = true;
@@ -152,6 +154,7 @@ class CharityDonationStatusCard extends StatelessWidget {
         isCurrentStepActive = false;
         break;
       case DeliveryState.delivered:
+      case DeliveryState.done:
       case DeliveryState.notUsed:
         currentStep = 5;
         isCurrentStepActive = true;
@@ -161,7 +164,7 @@ class CharityDonationStatusCard extends StatelessWidget {
     return UiProgressStepper(
       currentStep: currentStep,
       isCurrentStepActive: isCurrentStepActive,
-      isProgressComplete: delivery.state == DeliveryState.delivered,
+      isProgressComplete: delivery.state == DeliveryState.delivered || delivery.state == DeliveryState.done,
       icons: const [
         UiIconSpec.data(Icons.today_rounded),
         UiIconSpec.data(Icons.food_bank_rounded),
@@ -177,7 +180,7 @@ class CharityDonationStatusCard extends StatelessWidget {
       return null;
     }
 
-    final accepted = delivery.state == DeliveryState.accepted || delivery.state == DeliveryState.offered;
+    final accepted = delivery.state == DeliveryState.accepted || delivery.state == DeliveryState.onWayToPickUp;
     if (accepted && delivery.hasMeals || delivery.state == DeliveryState.inDelivery) {
       return UiDonationTimeRangeLabel(
         label: context.l10n.overviewDonationStatusCardTimerDeliveryLabel,
@@ -200,7 +203,7 @@ class CharityDonationStatusCard extends StatelessWidget {
       return null;
     }
 
-    final accepted = delivery.state == DeliveryState.accepted || delivery.state == DeliveryState.offered;
+    final accepted = delivery.state == DeliveryState.accepted || delivery.state == DeliveryState.onWayToPickUp;
     if (accepted && delivery.hasMeals || delivery.state == DeliveryState.inDelivery) {
       return UiOutlineButton(
         text: context.l10n.overviewDonationStatusCardDeliveryDetailsAction,

--- a/lib/common/data/dto/delivery_dto.dart
+++ b/lib/common/data/dto/delivery_dto.dart
@@ -45,14 +45,16 @@ class DeliveryDto {
 enum DeliveryStateDto {
   @JsonValue("PREPARED")
   prepared,
-  @JsonValue("OFFERED")
-  offered,
   @JsonValue("ACCEPTED")
   accepted,
+  @JsonValue("ON_WAY_TO_PICK_UP")
+  onWayToPickUp,
   @JsonValue("IN_DELIVERY")
   inDelivery,
   @JsonValue("DELIVERED")
   delivered,
+  @JsonValue("DONE")
+  done,
   @JsonValue("NOT_USED")
   notUsed;
 

--- a/lib/common/data/dto/delivery_dto.g.dart
+++ b/lib/common/data/dto/delivery_dto.g.dart
@@ -40,10 +40,11 @@ Map<String, dynamic> _$DeliveryDtoToJson(DeliveryDto instance) =>
 
 const _$DeliveryStateDtoEnumMap = {
   DeliveryStateDto.prepared: 'PREPARED',
-  DeliveryStateDto.offered: 'OFFERED',
   DeliveryStateDto.accepted: 'ACCEPTED',
+  DeliveryStateDto.onWayToPickUp: 'ON_WAY_TO_PICK_UP',
   DeliveryStateDto.inDelivery: 'IN_DELIVERY',
   DeliveryStateDto.delivered: 'DELIVERED',
+  DeliveryStateDto.done: 'DONE',
   DeliveryStateDto.notUsed: 'NOT_USED',
 };
 

--- a/lib/common/data/mapper/delivery_mapper.dart
+++ b/lib/common/data/mapper/delivery_mapper.dart
@@ -34,14 +34,16 @@ extension DeliveryStateMapper on DeliveryStateDto {
     switch (this) {
       case DeliveryStateDto.prepared:
         return DeliveryState.prepared;
-      case DeliveryStateDto.offered:
-        return DeliveryState.offered;
       case DeliveryStateDto.accepted:
         return DeliveryState.accepted;
+      case DeliveryStateDto.onWayToPickUp:
+        return DeliveryState.onWayToPickUp;
       case DeliveryStateDto.inDelivery:
         return DeliveryState.inDelivery;
       case DeliveryStateDto.delivered:
         return DeliveryState.delivered;
+      case DeliveryStateDto.done:
+        return DeliveryState.done;
       case DeliveryStateDto.notUsed:
         return DeliveryState.notUsed;
     }
@@ -55,14 +57,16 @@ extension DeliveryStateDtoMapper on DeliveryState {
     switch (this) {
       case DeliveryState.prepared:
         return DeliveryStateDto.prepared;
-      case DeliveryState.offered:
-        return DeliveryStateDto.offered;
       case DeliveryState.accepted:
         return DeliveryStateDto.accepted;
+      case DeliveryState.onWayToPickUp:
+        return DeliveryStateDto.onWayToPickUp;
       case DeliveryState.inDelivery:
         return DeliveryStateDto.inDelivery;
       case DeliveryState.delivered:
         return DeliveryStateDto.delivered;
+      case DeliveryState.done:
+        return DeliveryStateDto.done;
       case DeliveryState.notUsed:
         return DeliveryStateDto.notUsed;
     }

--- a/lib/common/data/service/delivery_service.dart
+++ b/lib/common/data/service/delivery_service.dart
@@ -10,10 +10,11 @@ import 'package:zachranobed/common/domain/utils/future_utils.dart';
 class DeliveryService {
   /// Valid states for delivery items in history.
   final List<String> _validHistoryStates = [
-    DeliveryStateDto.offered.toJson(),
     DeliveryStateDto.accepted.toJson(),
+    DeliveryStateDto.onWayToPickUp.toJson(),
     DeliveryStateDto.inDelivery.toJson(),
     DeliveryStateDto.delivered.toJson(),
+    DeliveryStateDto.done.toJson(),
   ];
 
   final _collection = FirebaseFirestore.instance.collection('deliveries').withConverter(

--- a/lib/common/domain/model/delivery.dart
+++ b/lib/common/domain/model/delivery.dart
@@ -22,10 +22,11 @@ abstract class Delivery with _$Delivery {
 
 enum DeliveryState {
   prepared,
-  offered,
   accepted,
+  onWayToPickUp,
   inDelivery,
   delivered,
+  done,
   notUsed,
 }
 

--- a/lib/features/food/data/repository/firebase_food_box_repository.dart
+++ b/lib/features/food/data/repository/firebase_food_box_repository.dart
@@ -137,7 +137,7 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
         deliveryDate: DateTime.now(),
         foodBoxes: foodBoxes.toList(),
         meals: [],
-        state: DeliveryStateDto.offered,
+        state: DeliveryStateDto.accepted,
         type: DeliveryTypeDto.boxDelivery,
         confirmationTime: user.activePair.confirmationTime.inMinutes,
       );

--- a/lib/features/food/data/repository/firebase_offered_food_repository.dart
+++ b/lib/features/food/data/repository/firebase_offered_food_repository.dart
@@ -7,7 +7,6 @@ import 'package:zachranobed/common/data/service/entity_pairs_service.dart';
 import 'package:zachranobed/common/data/service/meal_service.dart';
 import 'package:zachranobed/common/domain/model/delivery.dart';
 import 'package:zachranobed/common/domain/model/user_data.dart';
-import 'package:zachranobed/common/domain/repository/delivery_repository.dart';
 import 'package:zachranobed/common/domain/utils/iterable_utils.dart';
 import 'package:zachranobed/features/food/data/mapper/offered_food_mapper.dart';
 import 'package:zachranobed/features/food/domain/model/food_info.dart';
@@ -19,13 +18,11 @@ class FirebaseOfferedFoodRepository implements OfferedFoodRepository {
   final DeliveryService _deliveryService;
   final MealService _mealService;
   final EntityPairService _entityPairService;
-  final DeliveryRepository _deliveryRepository;
 
   FirebaseOfferedFoodRepository(
     this._deliveryService,
     this._mealService,
     this._entityPairService,
-    this._deliveryRepository,
   );
 
   @override
@@ -120,14 +117,6 @@ class FirebaseOfferedFoodRepository implements OfferedFoodRepository {
     );
 
     if (!moveBoxesSuccess) {
-      return false;
-    }
-
-    final updateStateSuccess = await _deliveryRepository.updateDeliveryState(
-      delivery: delivery,
-      state: DeliveryState.offered,
-    );
-    if (!updateStateSuccess) {
       return false;
     }
 

--- a/lib/features/food/di/food_dependency_container.dart
+++ b/lib/features/food/di/food_dependency_container.dart
@@ -3,7 +3,6 @@ import 'package:zachranobed/common/data/service/delivery_service.dart';
 import 'package:zachranobed/common/data/service/entity_pairs_service.dart';
 import 'package:zachranobed/common/data/service/food_box_service.dart';
 import 'package:zachranobed/common/data/service/meal_service.dart';
-import 'package:zachranobed/common/domain/repository/delivery_repository.dart';
 import 'package:zachranobed/features/food/data/repository/firebase_food_box_repository.dart';
 import 'package:zachranobed/features/food/data/repository/firebase_offered_food_repository.dart';
 import 'package:zachranobed/features/food/domain/repository/food_box_repository.dart';
@@ -36,7 +35,6 @@ class FoodDependencyContainer {
         GetIt.I<DeliveryService>(),
         GetIt.I<MealService>(),
         GetIt.I<EntityPairService>(),
-        GetIt.I<DeliveryRepository>(),
       ),
     );
 

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -77,7 +77,7 @@
       }
     },
     "foodCategoryBadgeCooled": "Chlazený",
-    "foodCategoryBadgePackaged": "Balený",
+    "foodCategoryBadgePackaged": "Kusový",
     "navigationLabelOverview": "Přehled",
     "navigationLabelHistory": "Historie",
     "navigationLabelNotifications": "Notifikace",


### PR DESCRIPTION
## Summary

Refactors the `DeliveryState` enum to more accurately reflect the real delivery lifecycle.

**Changes:**
- **Removes `offered`**: Removes the `OFFERED` state entirely. Canteen food offer no longer advances the delivery state explicitly from Flutter.
- **Adds `onWayToPickUp`**: New intermediate state between `accepted` and `inDelivery`. Represents the carrier being en route to the canteen pickup location.
- **Adds `done`**: New terminal state separate from `delivered`.
- **Box delivery initial state**: Changed from `OFFERED` → `ACCEPTED`.
- **UI cards updated**: `CanteenDonationStatusCard` and `CharityDonationStatusCard` reflect the new state machine with an additional stepper step for `onWayToPickUp`.
- **Delivery history filter**: Updated to include `onWayToPickUp` and `done`.