### PR TITLE
ZOB-407 Add boxes on the way

### DIFF
--- a/functions/src/functions/boxTransferFunction.ts
+++ b/functions/src/functions/boxTransferFunction.ts
@@ -35,9 +35,12 @@ export const boxTransfer = onDocumentUpdated(
     // Guard: only react to transitions TO DELIVERED
     if (oldValue.state === "DELIVERED" || newValue.state !== "DELIVERED") return;
 
-    // Guard: skip if boxes already transferred
-    if (newValue.foodBoxesTransferred === true) {
-      logger.info(`boxTransfer: already processed ${event.params.id}, skipping`);
+    // Guard: only process deliveries explicitly marked for server-side transfer.
+    // - false  → new app created this delivery, Cloud Function should transfer
+    // - true   → already transferred, skip
+    // - absent → old app created this delivery and transferred client-side, skip
+    if (newValue.foodBoxesTransferred !== false) {
+      logger.info(`boxTransfer: skipping ${event.params.id} (foodBoxesTransferred=${newValue.foodBoxesTransferred})`);
       return;
     }
 

--- a/functions/src/functions/boxTransferFunction.ts
+++ b/functions/src/functions/boxTransferFunction.ts
@@ -1,0 +1,140 @@
+import {onDocumentUpdated} from "firebase-functions/v2/firestore";
+import {logger} from "firebase-functions/v2";
+import {z} from "zod";
+import {db} from "../config/firebase";
+import {DeliverySchema} from "../models";
+import {getEntityPairs, clearEntityCache} from "../services/entityService";
+
+/**
+ * Schema for parsing individual food box items from the delivery's foodBoxes
+ * array. The delivery stores these as z.array(z.any()), so we parse each
+ * element explicitly.
+ */
+const DeliveryFoodBoxSchema = z.object({
+  foodBoxId: z.string(),
+  count: z.number(),
+});
+
+/**
+ * Firestore onDocumentUpdated trigger that transfers box counts in the
+ * EntityPair document when a delivery transitions to the DELIVERED state.
+ *
+ * For FOOD_DELIVERY (canteen → charity): donorCount decreases, recipientCount increases.
+ * For BOX_DELIVERY (charity → canteen): donorCount increases, recipientCount decreases.
+ *
+ * Uses a Firestore transaction to prevent race conditions when multiple
+ * deliveries for the same entity pair are delivered simultaneously.
+ */
+export const boxTransfer = onDocumentUpdated(
+  "deliveries/{id}",
+  async (event) => {
+    const oldValue = event.data?.before?.data();
+    const newValue = event.data?.after?.data();
+    if (!oldValue || !newValue) return;
+
+    // Guard: only react to transitions TO DELIVERED
+    if (oldValue.state === "DELIVERED" || newValue.state !== "DELIVERED") return;
+
+    // Guard: skip if boxes already transferred
+    if (newValue.foodBoxesTransferred === true) {
+      logger.info(`boxTransfer: already processed ${event.params.id}, skipping`);
+      return;
+    }
+
+    const docRef = event.data!.after.ref;
+    const result = DeliverySchema.safeParse({ ref: docRef, ...newValue });
+    if (!result.success) {
+      logger.warn(`boxTransfer: invalid delivery document ${event.params.id}`, result.error);
+      return;
+    }
+
+    const delivery = result.data;
+
+    // Guard: skip deliveries without food boxes
+    if (!delivery.foodBoxes || delivery.foodBoxes.length === 0) {
+      logger.info(`boxTransfer: no foodBoxes on ${event.params.id}, skipping`);
+      return;
+    }
+
+    // Parse delivery food boxes and build change map
+    const changeMap: Record<string, number> = {};
+    for (const item of delivery.foodBoxes) {
+      const parsed = DeliveryFoodBoxSchema.safeParse(item);
+      if (!parsed.success) {
+        logger.warn(`boxTransfer: invalid foodBox item on ${event.params.id}`, parsed.error);
+        continue;
+      }
+      const {foodBoxId, count} = parsed.data;
+      changeMap[foodBoxId] = (changeMap[foodBoxId] || 0) + count;
+    }
+
+    if (Object.keys(changeMap).length === 0) {
+      logger.warn(`boxTransfer: no valid foodBoxes on ${event.params.id}`);
+      return;
+    }
+
+    // FOOD_DELIVERY: donor sends to recipient (donorCount -, recipientCount +)
+    // BOX_DELIVERY: recipient returns to donor (donorCount +, recipientCount -)
+    const direction = delivery.type === "FOOD_DELIVERY" ? 1 : -1;
+
+    logger.info(
+      `boxTransfer: processing ${event.params.id}, type=${delivery.type}, ` +
+      `donor=${delivery.donorId}, recipient=${delivery.recipientId}`,
+    );
+
+    try {
+      const entityPairs = await getEntityPairs();
+      const entityPair = entityPairs.find(
+        (pair) =>
+          pair.donorId === delivery.donorId &&
+          pair.recipientId === delivery.recipientId,
+      );
+
+      if (!entityPair) {
+        logger.error(
+          `boxTransfer: no EntityPair found for ` +
+          `donor=${delivery.donorId} recipient=${delivery.recipientId}`,
+        );
+        return;
+      }
+
+      await db.runTransaction(async (transaction) => {
+        const pairDoc = await transaction.get(entityPair.ref);
+        if (!pairDoc.exists) {
+          throw new Error(`EntityPair ${entityPair.ref.id} disappeared during transaction`);
+        }
+
+        const pairData = pairDoc.data()!;
+        const foodboxes = pairData.foodboxes;
+
+        if (!foodboxes || !Array.isArray(foodboxes)) {
+          throw new Error(`EntityPair ${entityPair.ref.id} has no foodboxes array`);
+        }
+
+        const updatedFoodboxes = foodboxes.map(
+          (box: Record<string, unknown>) => {
+            const foodBoxId = box.foodBoxId as string;
+            const changeCount = changeMap[foodBoxId] || 0;
+            if (changeCount === 0) return box;
+
+            return {
+              ...box,
+              donorCount: (box.donorCount as number) - direction * changeCount,
+              recipientCount: (box.recipientCount as number) + direction * changeCount,
+            };
+          },
+        );
+
+        transaction.update(entityPair.ref, {foodboxes: updatedFoodboxes});
+      });
+
+      await docRef.update({foodBoxesTransferred: true});
+
+      logger.info(`boxTransfer: successfully transferred boxes for ${event.params.id}`);
+    } catch (error) {
+      logger.error(`boxTransfer: failed for ${event.params.id}:`, error);
+    } finally {
+      clearEntityCache();
+    }
+  },
+);

--- a/functions/src/functions/boxTransferFunction.ts
+++ b/functions/src/functions/boxTransferFunction.ts
@@ -47,7 +47,7 @@ export const boxTransfer = onDocumentUpdated(
     const docRef = event.data!.after.ref;
     const result = DeliverySchema.safeParse({ ref: docRef, ...newValue });
     if (!result.success) {
-      logger.warn(`boxTransfer: invalid delivery document ${event.params.id}`, result.error);
+      logger.error(`boxTransfer: invalid delivery document ${event.params.id}`, result.error);
       return;
     }
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,6 +12,7 @@ import { dodoOrderStatus } from "./functions/dodoOrderStatusFunction";
 import { cloudTaskHandler } from "./functions/cloudTaskHandlerFunction";
 import { boxDeliveryCreated } from "./functions/boxDeliveryCreatedFunction";
 import { confirmationReminderHandler } from "./functions/notifications/confirmationReminderFunction";
+import { boxTransfer } from "./functions/boxTransferFunction";
 import {
   finalizeDeliveriesFunction,
   finalizeDeliveries,
@@ -113,6 +114,7 @@ exports.confirmationReminderHandler = confirmationReminderHandler;
 // Export Firestore triggers
 exports.boxDeliveryCreated = boxDeliveryCreated;
 exports.orderDeliveryService = orderDeliveryService;
+exports.boxTransfer = boxTransfer;
 
 // Export scheduled functions
 exports.sendOrdersFunction = sendOrdersFunction;

--- a/functions/src/models/Delivery.ts
+++ b/functions/src/models/Delivery.ts
@@ -56,6 +56,8 @@ export const DeliverySchema = z.object({
   meals: z.array(z.any()).default([]),
   /** Carrier order metadata (set when DODO order created) */
   carrierOrder: CarrierOrderSchema.optional(),
+  /** Whether box counts have been transferred by the Cloud Function */
+  foodBoxesTransferred: z.boolean().optional(),
   /** Minutes before pickup to confirm (overrides carrier default) */
   confirmationTime: z.number().optional(),
 });

--- a/lib/app/presentation/widget/food_boxes_overview_section.dart
+++ b/lib/app/presentation/widget/food_boxes_overview_section.dart
@@ -196,8 +196,8 @@ class _FoodBoxesOverviewSectionState extends State<FoodBoxesOverviewSection> {
 
   Widget _buildSmallTile(BuildContext context, FoodBoxStatistics stat) {
     final value = switch (widget.user) {
-      Canteen() => stat.quantityAtCanteen,
-      Charity() => stat.quantityAtCharity,
+      Canteen() => stat.availableQuantityAtCanteen,
+      Charity() => stat.availableQuantityAtCharity,
     };
 
     return UiFoodBoxTile(

--- a/lib/common/data/dto/delivery_dto.dart
+++ b/lib/common/data/dto/delivery_dto.dart
@@ -24,6 +24,8 @@ class DeliveryDto {
   @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
   final DeliveryTypeDto? type;
   final int? confirmationTime;
+  @JsonKey(includeIfNull: false)
+  final bool? foodBoxesTransferred;
 
   DeliveryDto({
     required this.id,
@@ -35,6 +37,7 @@ class DeliveryDto {
     required this.state,
     required this.type,
     required this.confirmationTime,
+    required this.foodBoxesTransferred,
   });
 
   factory DeliveryDto.fromJson(Map<String, dynamic> json) => _$DeliveryDtoFromJson(json);

--- a/lib/common/data/dto/delivery_dto.g.dart
+++ b/lib/common/data/dto/delivery_dto.g.dart
@@ -23,6 +23,7 @@ DeliveryDto _$DeliveryDtoFromJson(Map<String, dynamic> json) => DeliveryDto(
       type: $enumDecodeNullable(_$DeliveryTypeDtoEnumMap, json['type'],
           unknownValue: JsonKey.nullForUndefinedEnumValue),
       confirmationTime: (json['confirmationTime'] as num?)?.toInt(),
+      foodBoxesTransferred: json['foodBoxesTransferred'] as bool?,
     );
 
 Map<String, dynamic> _$DeliveryDtoToJson(DeliveryDto instance) =>
@@ -36,6 +37,8 @@ Map<String, dynamic> _$DeliveryDtoToJson(DeliveryDto instance) =>
       'state': instance.state?.toJson(),
       'type': instance.type?.toJson(),
       'confirmationTime': instance.confirmationTime,
+      if (instance.foodBoxesTransferred case final value?)
+        'foodBoxesTransferred': value,
     };
 
 const _$DeliveryStateDtoEnumMap = {

--- a/lib/common/data/repository/firebase_delivery_repository.dart
+++ b/lib/common/data/repository/firebase_delivery_repository.dart
@@ -62,6 +62,7 @@ class FirebaseDeliveryRepository implements DeliveryRepository {
       state: DeliveryStateDto.prepared,
       type: DeliveryTypeDto.foodDelivery,
       confirmationTime: user.activePair.confirmationTime.inMinutes,
+      foodBoxesTransferred: null,
     );
 
     return _deliveryService.createDelivery(newDelivery);

--- a/lib/common/data/service/delivery_service.dart
+++ b/lib/common/data/service/delivery_service.dart
@@ -82,27 +82,6 @@ class DeliveryService {
     return await _collection.doc(id).update({'state': state.toJson()}).toSuccess();
   }
 
-  /// Queries the Firestore collection for deliveries of the given pair defined
-  /// by [donorId] and [recipientId] of the offered food. It allows an optional
-  /// parameter for specifying a [timePeriod] to filter the results.
-  Future<Iterable<DeliveryDto>> getDeliveries({
-    required String donorId,
-    required String recipientId,
-    int? timePeriod,
-  }) async {
-    var query = _collection.where(_hasEntity(donorId, recipientId));
-
-    if (timePeriod != null) {
-      query = query.where(
-        'deliveryDate',
-        isGreaterThan: DateTime.now().subtract(Duration(days: timePeriod)),
-      );
-    }
-
-    final snapshot = await query.get();
-    return snapshot.docs.map((doc) => doc.data());
-  }
-
   /// Sets up a Firestore stream to listen for changes in the `deliveries`
   /// collection, filtering deliveries based on the provided pair of [donorId]
   /// and [recipientId].
@@ -216,6 +195,31 @@ class DeliveryService {
     return _collection //
         .doc(id)
         .update({'foodBoxes': foodBoxes.map((e) => e.toJson())}).toSuccess();
+  }
+
+  /// Observes active deliveries (not yet delivered or cancelled) for a given
+  /// donor-recipient pair.
+  Stream<Iterable<DeliveryDto>> observeActiveDeliveries({
+    required String donorId,
+    required String recipientId,
+  }) {
+    final activeStates = [
+      DeliveryStateDto.accepted.toJson(),
+      DeliveryStateDto.onWayToPickUp.toJson(),
+      DeliveryStateDto.inDelivery.toJson(),
+    ];
+
+    final query = _collection
+        .where(
+          Filter.and(
+            Filter('state', whereIn: activeStates),
+            Filter('donorId', isEqualTo: donorId),
+            Filter('recipientId', isEqualTo: recipientId),
+          ),
+        )
+        .where('deliveryDate', isGreaterThanOrEqualTo: DateTimeUtils.lastMidnight());
+
+    return query.snapshots().map((snapshot) => snapshot.docs.map((doc) => doc.data()));
   }
 
   /// Prepares a filter to get only deliveries of the offered food for the given

--- a/lib/common/data/service/delivery_service.dart
+++ b/lib/common/data/service/delivery_service.dart
@@ -174,7 +174,17 @@ class DeliveryService {
       ),
     );
 
-    return updateDeliveryFoodboxes(id, foodBoxes.toList());
+    final updateData = <String, dynamic>{
+      'foodBoxes': foodBoxes.map((e) => e.toJson()).toList(),
+    };
+
+    // Mark delivery for server-side box transfer (via Cloud Function).
+    // Skip if already transferred to avoid resetting it back to false.
+    if (delivery?.foodBoxesTransferred != true) {
+      updateData['foodBoxesTransferred'] = false;
+    }
+
+    return _collection.doc(id).update(updateData).toSuccess();
   }
 
   /// Creates a delivery from the given [dto] instance.

--- a/lib/features/food/data/repository/firebase_food_box_repository.dart
+++ b/lib/features/food/data/repository/firebase_food_box_repository.dart
@@ -67,10 +67,6 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
     );
 
     yield* Rx.combineLatest2(pairStream, activeDeliveriesStream, (pair, activeDeliveries) {
-      return (pair, activeDeliveries);
-    }).map((combined) {
-      final (pair, activeDeliveries) = combined;
-
       // Accumulate pair counts
       final Map<String, FoodBoxPairDto> boxesCountMap = {};
       for (final foodBox in pair?.foodboxes ?? <FoodBoxPairDto>[]) {

--- a/lib/features/food/data/repository/firebase_food_box_repository.dart
+++ b/lib/features/food/data/repository/firebase_food_box_repository.dart
@@ -168,6 +168,7 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
         state: DeliveryStateDto.accepted,
         type: DeliveryTypeDto.boxDelivery,
         confirmationTime: user.activePair.confirmationTime.inMinutes,
+        foodBoxesTransferred: false,
       );
       return _deliveryService.createDelivery(newDelivery);
     } else {

--- a/lib/features/food/data/repository/firebase_food_box_repository.dart
+++ b/lib/features/food/data/repository/firebase_food_box_repository.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:zachranobed/common/data/dto/delivery_dto.dart';
 import 'package:zachranobed/common/data/dto/food_box_delivery_dto.dart';
 import 'package:zachranobed/common/data/dto/food_box_pair_dto.dart';
@@ -51,16 +52,27 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
     // every change in the stream.
     final typesList = await getTypes();
     final typesMap = {for (final v in typesList) v.id: v};
+
+    final donorId = user.activePair.donorId;
+    final recipientId = user.activePair.recipientId;
+
     final pairStream = _entityPairService.observePair(
-      donorId: user.activePair.donorId,
-      recipientId: user.activePair.recipientId,
+      donorId: donorId,
+      recipientId: recipientId,
     );
 
-    yield* pairStream.map((pair) {
-      // Create accumulator map, as multiple pairs may have same food box types
-      // and we would like to show aggregated statistics across all pairs.
-      final Map<String, FoodBoxPairDto> boxesCountMap = {};
+    final activeDeliveriesStream = _deliveryService.observeActiveDeliveries(
+      donorId: donorId,
+      recipientId: recipientId,
+    );
 
+    yield* Rx.combineLatest2(pairStream, activeDeliveriesStream, (pair, activeDeliveries) {
+      return (pair, activeDeliveries);
+    }).map((combined) {
+      final (pair, activeDeliveries) = combined;
+
+      // Accumulate pair counts
+      final Map<String, FoodBoxPairDto> boxesCountMap = {};
       for (final foodBox in pair?.foodboxes ?? <FoodBoxPairDto>[]) {
         final acc = boxesCountMap[foodBox.foodBoxId];
         boxesCountMap[foodBox.foodBoxId] = FoodBoxPairDto(
@@ -71,18 +83,47 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
         );
       }
 
+      // Accumulate in-transit counts from active deliveries
+      final Map<String, int> onTheWayToCharity = {};
+      final Map<String, int> onTheWayToCanteen = {};
+
+      for (final delivery in activeDeliveries) {
+        if (delivery.foodBoxes.isEmpty) {
+          // Skip deliveries without food boxes
+          continue;
+        }
+
+        final target = switch (delivery.type) {
+          DeliveryTypeDto.foodDelivery => onTheWayToCharity,
+          DeliveryTypeDto.boxDelivery => onTheWayToCanteen,
+          _ => null,
+        };
+
+        if (target == null) {
+          // Skip deliveries with invalid type
+          continue;
+        }
+
+        for (final box in delivery.foodBoxes) {
+          target[box.foodBoxId] = (target[box.foodBoxId] ?? 0) + box.count;
+        }
+      }
+
       // Map accumulated values to domain instances
       return boxesCountMap.values.mapNotNull((element) {
-        // In case that type is not known, ignore this food box data
         final type = typesMap[element.foodBoxId];
         if (type == null) {
+          // In case that type is not known, ignore this food box data
           return null;
         }
+
         return FoodBoxStatistics(
           type: type,
           totalQuantity: element.count,
           quantityAtCanteen: element.donorCount,
           quantityAtCharity: element.recipientCount,
+          quantityOnTheWayToCharity: onTheWayToCharity[element.foodBoxId] ?? 0,
+          quantityOnTheWayToCanteen: onTheWayToCanteen[element.foodBoxId] ?? 0,
         );
       }).sorted((a, b) {
         return _getSortOrder(a.type).compareTo(_getSortOrder(b.type));
@@ -97,15 +138,6 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
   }) async {
     final donorId = user.activePair.donorId;
     final recipientId = user.activePair.recipientId;
-    final moveBoxesSuccess = await _entityPairService.moveBoxesToDonor(
-      donorId: donorId,
-      recipientId: recipientId,
-      changeMap: boxesQuantity,
-    );
-
-    if (!moveBoxesSuccess) {
-      return false;
-    }
 
     // Prepare delivery ID and check if any exists in Firebase
     final id = '$recipientId-$donorId-${DateTimeUtils.getCurrentDayMark()}';

--- a/lib/features/food/data/repository/firebase_offered_food_repository.dart
+++ b/lib/features/food/data/repository/firebase_offered_food_repository.dart
@@ -3,7 +3,6 @@ import 'package:zachranobed/common/data/dto/delivery_dto.dart';
 import 'package:zachranobed/common/data/dto/meal_detail_dto.dart';
 import 'package:zachranobed/common/data/dto/meal_dto.dart';
 import 'package:zachranobed/common/data/service/delivery_service.dart';
-import 'package:zachranobed/common/data/service/entity_pairs_service.dart';
 import 'package:zachranobed/common/data/service/meal_service.dart';
 import 'package:zachranobed/common/domain/model/delivery.dart';
 import 'package:zachranobed/common/domain/model/user_data.dart';
@@ -17,12 +16,10 @@ import 'package:zachranobed/features/food/domain/repository/offered_food_reposit
 class FirebaseOfferedFoodRepository implements OfferedFoodRepository {
   final DeliveryService _deliveryService;
   final MealService _mealService;
-  final EntityPairService _entityPairService;
 
   FirebaseOfferedFoodRepository(
     this._deliveryService,
     this._mealService,
-    this._entityPairService,
   );
 
   @override
@@ -107,16 +104,6 @@ class FirebaseOfferedFoodRepository implements OfferedFoodRepository {
     }
 
     if (!await _deliveryService.addMealsAndBoxes(delivery.id, meals, boxInfo)) {
-      return false;
-    }
-
-    final moveBoxesSuccess = await _entityPairService.moveBoxesToRecipient(
-      donorId: delivery.donorId,
-      recipientId: delivery.recipientId,
-      changeMap: boxInfo,
-    );
-
-    if (!moveBoxesSuccess) {
       return false;
     }
 

--- a/lib/features/food/di/food_dependency_container.dart
+++ b/lib/features/food/di/food_dependency_container.dart
@@ -34,7 +34,6 @@ class FoodDependencyContainer {
       FirebaseOfferedFoodRepository(
         GetIt.I<DeliveryService>(),
         GetIt.I<MealService>(),
-        GetIt.I<EntityPairService>(),
       ),
     );
 

--- a/lib/features/food/domain/model/food_box_statistics.dart
+++ b/lib/features/food/domain/model/food_box_statistics.dart
@@ -1,15 +1,52 @@
 import 'package:zachranobed/features/food/domain/model/food_box_type.dart';
 
+/// Statistics for a single food box type within a donor–recipient pair.
+///
+/// Counts are split into three categories:
+/// - **At canteen / at charity** — boxes physically held by each side
+///   (stored in the EntityPair `donorCount` / `recipientCount`).
+/// - **On the way** — boxes in active deliveries that haven't reached
+///   `delivered` state yet. Derived from delivery documents, not stored
+///   in EntityPair.
+///
+/// Invariant: [totalQuantity] == [quantityAtCanteen] + [quantityAtCharity].
 class FoodBoxStatistics {
+  /// The box type these statistics belong to.
   final FoodBoxType type;
+
+  /// Total number of boxes of this type across both sides.
   final int totalQuantity;
+
+  /// Boxes currently held by the charity (recipient).
   final int quantityAtCharity;
+
+  /// Boxes currently held by the canteen (donor).
   final int quantityAtCanteen;
+
+  /// Boxes in active food deliveries heading from canteen to charity.
+  final int quantityOnTheWayToCharity;
+
+  /// Boxes in active box return deliveries heading from charity to canteen.
+  final int quantityOnTheWayToCanteen;
 
   const FoodBoxStatistics({
     required this.type,
     required this.totalQuantity,
     required this.quantityAtCharity,
     required this.quantityAtCanteen,
+    required this.quantityOnTheWayToCharity,
+    required this.quantityOnTheWayToCanteen,
   });
+
+  /// Boxes the charity can use — excludes those already on the way back.
+  int get availableQuantityAtCharity =>
+      quantityAtCharity - quantityOnTheWayToCanteen;
+
+  /// Boxes the canteen can use — excludes those already on the way out.
+  int get availableQuantityAtCanteen =>
+      quantityAtCanteen - quantityOnTheWayToCharity;
+
+  /// Total boxes currently in transit in either direction.
+  int get quantityOnTheWay =>
+      quantityOnTheWayToCharity + quantityOnTheWayToCanteen;
 }

--- a/lib/features/food/domain/model/food_box_statistics.dart
+++ b/lib/features/food/domain/model/food_box_statistics.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:zachranobed/features/food/domain/model/food_box_type.dart';
 
 /// Statistics for a single food box type within a donor–recipient pair.
@@ -40,11 +42,11 @@ class FoodBoxStatistics {
 
   /// Boxes the charity can use — excludes those already on the way back.
   int get availableQuantityAtCharity =>
-      quantityAtCharity - quantityOnTheWayToCanteen;
+      max(quantityAtCharity - quantityOnTheWayToCanteen, 0);
 
   /// Boxes the canteen can use — excludes those already on the way out.
   int get availableQuantityAtCanteen =>
-      quantityAtCanteen - quantityOnTheWayToCharity;
+      max(quantityAtCanteen - quantityOnTheWayToCharity, 0);
 
   /// Total boxes currently in transit in either direction.
   int get quantityOnTheWay =>

--- a/lib/features/food/domain/usecase/verify_available_box_count_use_case.dart
+++ b/lib/features/food/domain/usecase/verify_available_box_count_use_case.dart
@@ -18,8 +18,8 @@ class VerifyAvailableBoxCountUseCase {
     required Map<String, int> requiredBoxes,
   }) async {
     int Function(FoodBoxStatistics?) getQuantity = switch (user) {
-      Canteen() => (statistics) => statistics?.quantityAtCanteen ?? 0,
-      Charity() => (statistics) => statistics?.quantityAtCharity ?? 0,
+      Canteen() => (statistics) => statistics?.availableQuantityAtCanteen ?? 0,
+      Charity() => (statistics) => statistics?.availableQuantityAtCharity ?? 0,
     };
 
     final statistics = await _repository.observeStatistics(user).first;

--- a/lib/features/food/presentation/screens/offer_food_boxes_screen.dart
+++ b/lib/features/food/presentation/screens/offer_food_boxes_screen.dart
@@ -80,7 +80,7 @@ class _OfferFoodBoxesScreenState extends State<OfferFoodBoxesScreen> {
             if (snapshot.hasError || snapshot.data == null) {
               return ErrorPage(onRetryPressed: _loadStatistics);
             }
-            final availableBoxes = snapshot.requireData.where((statistics) => statistics.quantityAtCanteen > 0);
+            final availableBoxes = snapshot.requireData.where((s) => s.availableQuantityAtCanteen > 0);
             if (availableBoxes.isEmpty) {
               return _buildEmptyPage();
             }
@@ -137,11 +137,11 @@ class _OfferFoodBoxesScreenState extends State<OfferFoodBoxesScreen> {
           ...availableBoxes.map((value) {
             return UiBoxCounterTile(
               title: value.type.name,
-              subtitle: context.l10n.totalCountOfBoxes(value.quantityAtCanteen),
+              subtitle: context.l10n.totalCountOfBoxes(value.availableQuantityAtCanteen),
               counterField: UiCounterField(
                 label: context.l10n.numberOfBoxes,
                 value: _boxesQuantity[value.type] ?? 0,
-                maxValue: value.quantityAtCanteen,
+                maxValue: value.availableQuantityAtCanteen,
                 onChanged: (count) {
                   setState(() {
                     _boxesQuantity[value.type] = count;

--- a/lib/features/food/presentation/screens/order_shipping_of_boxes_screen.dart
+++ b/lib/features/food/presentation/screens/order_shipping_of_boxes_screen.dart
@@ -101,7 +101,7 @@ class _OrderShippingOfBoxesScreenState extends State<OrderShippingOfBoxesScreen>
             if (snapshot.hasError || snapshot.data == null) {
               return ErrorPage(onRetryPressed: _loadStatistics);
             }
-            final availableBoxes = snapshot.requireData.where((statistics) => statistics.quantityAtCharity > 0);
+            final availableBoxes = snapshot.requireData.where((s) => s.availableQuantityAtCharity > 0);
             if (availableBoxes.isEmpty) {
               return _buildEmptyPage();
             }
@@ -169,13 +169,11 @@ class _OrderShippingOfBoxesScreenState extends State<OrderShippingOfBoxesScreen>
           ...availableBoxes.map((value) {
             return UiBoxCounterTile(
               title: value.type.name,
-              subtitle: context.l10n.totalCountOfBoxes(
-                value.quantityAtCharity,
-              ),
+              subtitle: context.l10n.totalCountOfBoxes(value.availableQuantityAtCharity),
               counterField: UiCounterField(
                 label: context.l10n.numberOfBoxes,
                 value: _boxesQuantity[value.type.id] ?? 0,
-                maxValue: value.quantityAtCharity,
+                maxValue: value.availableQuantityAtCharity,
                 onChanged: (count) {
                   setState(() {
                     _boxesQuantity[value.type.id] = count;

--- a/lib/features/food/presentation/widget/food_box_tile_stat_factory.dart
+++ b/lib/features/food/presentation/widget/food_box_tile_stat_factory.dart
@@ -27,22 +27,30 @@ class FoodBoxTileStatFactory {
       case Canteen():
         return [
           UiFoodBoxTileStat(
-            value: stat.quantityAtCanteen,
+            value: stat.availableQuantityAtCanteen,
             label: context.l10n.overviewFoodBoxesAvailableLabel,
           ),
           UiFoodBoxTileStat(
-            value: stat.quantityAtCharity,
+            value: stat.quantityOnTheWay,
+            label: context.l10n.overviewFoodBoxesOnTheWayLabel,
+          ),
+          UiFoodBoxTileStat(
+            value: stat.availableQuantityAtCharity,
             label: context.l10n.charity,
           ),
         ];
       case Charity():
         return [
           UiFoodBoxTileStat(
-            value: stat.quantityAtCharity,
+            value: stat.availableQuantityAtCharity,
             label: context.l10n.overviewFoodBoxesAvailableLabel,
           ),
           UiFoodBoxTileStat(
-            value: stat.quantityAtCanteen,
+            value: stat.quantityOnTheWay,
+            label: context.l10n.overviewFoodBoxesOnTheWayLabel,
+          ),
+          UiFoodBoxTileStat(
+            value: stat.availableQuantityAtCanteen,
             label: context.l10n.canteen,
           ),
         ];

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -349,6 +349,7 @@
     "overviewFoodBoxesHeaderTitle": "Vratné krabičky",
     "overviewFoodBoxesShowAllAction": "Zobrazit vše",
     "overviewFoodBoxesAvailableLabel": "K dispozici",
+    "overviewFoodBoxesOnTheWayLabel": "Na cestě",
     "overviewFoodBoxesTotalLabel": "Celkem {count} ks",
     "@overviewFoodBoxesTotalLabel": {
         "placeholders": {


### PR DESCRIPTION
## Summary

* Defers box count transfers from immediate (on delivery creation) to confirmed (on delivery completion). Introduces in-transit counters derived from active delivery documents and exposes `available*` getters that subtract in-transit boxes.
