### PR TITLE
Creation of dodo order for food delivery (fix/dodo-order-creation)

### DIFF
--- a/functions/src/functions/dodoOrderStatusFunction.ts
+++ b/functions/src/functions/dodoOrderStatusFunction.ts
@@ -108,7 +108,7 @@ export const dodoOrderStatus = onRequest(
       OrderStatus,
     );
     logger.info(
-      `${T} 🔄 Updating delivery state for ${identifier} to ${OrderStatus}`,
+      `${T} 🔄 Updating delivery state for ${identifier} to ${OrderStatus}. Result: ${JSON.stringify(result)}`,
     );
 
     // 6. Return success

--- a/functions/src/functions/orderDeliveryServiceFunction.ts
+++ b/functions/src/functions/orderDeliveryServiceFunction.ts
@@ -1,0 +1,109 @@
+import { onDocumentUpdated } from "firebase-functions/v2/firestore";
+import { logger } from "firebase-functions/v2";
+import { Timestamp } from "firebase-admin/firestore";
+import { DeliverySchema } from "../models";
+import { getEntityPairs, getEntities, clearEntityCache } from "../services/entityService";
+import { updateDeliveryWithOrderCreationTime } from "../services/deliveryService";
+import { getDodoToken, createDodoOrder, createFoodDeliveryOrder } from "../services/dodoService";
+import {
+  dodoClientId,
+  dodoClientSecret,
+  dodoOauthUri,
+  dodoScope,
+  dodoOrdersApi,
+} from "../config/firebase";
+
+/**
+ * Firestore onDocumentUpdated trigger that creates a DODO carrier order
+ * when a FOOD_DELIVERY transitions to ACCEPTED state.
+ */
+export const orderDeliveryService = onDocumentUpdated(
+  {
+    document: "deliveries/{id}",
+    secrets: [dodoClientId, dodoClientSecret, dodoOauthUri, dodoScope, dodoOrdersApi],
+  },
+  async (event) => {
+    const oldValue = event.data?.before?.data();
+    const newValue = event.data?.after?.data();
+    if (!oldValue || !newValue) return;
+
+    // Guard: only react to transitions TO ACCEPTED
+    if (oldValue.state === "ACCEPTED" || newValue.state !== "ACCEPTED") return;
+
+    const docRef = event.data!.after.ref;
+    const result = DeliverySchema.safeParse({ ref: docRef, ...newValue });
+    if (!result.success) {
+      logger.warn(`orderDeliveryService: invalid delivery document ${event.params.id}`, result.error);
+      return;
+    }
+
+    const delivery = result.data;
+
+    // Guard: only FOOD_DELIVERY with DODO carrier
+    if (delivery.type !== "FOOD_DELIVERY") return;
+    if (delivery.carrierId !== "dodo") return;
+
+    // Guard: idempotency — skip if DODO order already created
+    if (delivery.carrierOrder?.createdAt) {
+      logger.info(`orderDeliveryService: carrierOrder already exists for ${event.params.id}, skipping`);
+      return;
+    }
+
+    // Guard: required fields must be present (set by sendOrdersFunction)
+    if (!delivery.deliveryIdentifier || !delivery.pickupTimeWindow || !delivery.deliveryTimeWindow) {
+      logger.error(`orderDeliveryService: missing required fields on ${event.params.id}`);
+      return;
+    }
+
+    try {
+      const [entityPairs, entities] = await Promise.all([
+        getEntityPairs(),
+        getEntities(),
+      ]);
+
+      const entityPair = entityPairs.find(
+        (pair) =>
+          pair.donorId === delivery.donorId &&
+          pair.recipientId === delivery.recipientId,
+      );
+
+      if (!entityPair) {
+        logger.error(
+          `orderDeliveryService: no entity pair found for donor=${delivery.donorId} recipient=${delivery.recipientId}`,
+        );
+        return;
+      }
+
+      const donor = entities.find((e) => e.id === entityPair.donorId);
+      const recipient = entities.find((e) => e.id === entityPair.recipientId);
+
+      if (!donor || !recipient) {
+        logger.error(
+          `orderDeliveryService: donor or recipient entity not found for pair donor=${delivery.donorId} recipient=${delivery.recipientId}`,
+        );
+        return;
+      }
+
+      const pickupStart = delivery.pickupTimeWindow.start.toDate();
+      const pickupEnd = delivery.pickupTimeWindow.end.toDate();
+      const deliveryStart = delivery.deliveryTimeWindow.start.toDate();
+      const deliveryEnd = delivery.deliveryTimeWindow.end.toDate();
+
+      const dodoToken = await getDodoToken();
+      const order = createFoodDeliveryOrder(
+        entityPair, donor, recipient, delivery.deliveryIdentifier,
+        pickupStart, pickupEnd, deliveryStart, deliveryEnd,
+      );
+      const orderCreated = await createDodoOrder(order, dodoToken);
+
+      if (orderCreated) {
+        await updateDeliveryWithOrderCreationTime(docRef, { createdAt: Timestamp.now() });
+        logger.info(`orderDeliveryService: DODO order created for ${event.params.id}`);
+      } else {
+        logger.error(`orderDeliveryService: DODO order creation failed for ${event.params.id}`);
+      }
+    } finally {
+      clearEntityCache();
+    }
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,7 @@ import { sendOrdersFunction, sendOrders } from "./functions/sendOrdersFunction";
 import { dodoOrderStatus } from "./functions/dodoOrderStatusFunction";
 import { cloudTaskHandler } from "./functions/cloudTaskHandlerFunction";
 import { boxDeliveryCreated } from "./functions/boxDeliveryCreatedFunction";
+import { orderDeliveryService } from "./functions/orderDeliveryServiceFunction";
 import {
   finalizeDeliveriesFunction,
   finalizeDeliveries,
@@ -103,6 +104,7 @@ exports.cloudTaskHandler = cloudTaskHandler;
 
 // Export Firestore triggers
 exports.boxDeliveryCreated = boxDeliveryCreated;
+exports.orderDeliveryService = orderDeliveryService;
 
 // Export scheduled functions
 exports.sendOrdersFunction = sendOrdersFunction;

--- a/functions/src/services/dodoService.ts
+++ b/functions/src/services/dodoService.ts
@@ -152,6 +152,54 @@ export async function createDodoOrder(
 }
 
 /**
+ * Build a food delivery DODO order object from entity data and pre-calculated time windows.
+ * Pickup is from the donor, delivery is to the recipient.
+ * @param {EntityPair} entityPair - The entity pair
+ * @param {Entity} donor - The donor entity
+ * @param {Entity} recipient - The recipient entity
+ * @param {string} deliveryIdentifier - The delivery identifier
+ * @param {Date} pickupStart - Pre-computed pickup window start
+ * @param {Date} pickupEnd - Pre-computed pickup window end
+ * @param {Date} deliveryStart - Pre-computed delivery window start
+ * @param {Date} deliveryEnd - Pre-computed delivery window end
+ * @return {DodoOrder} The food delivery order
+ */
+export function createFoodDeliveryOrder(
+  entityPair: EntityPair,
+  donor: Entity,
+  recipient: Entity,
+  deliveryIdentifier: string,
+  pickupStart: Date,
+  pickupEnd: Date,
+  deliveryStart: Date,
+  deliveryEnd: Date,
+): DodoOrder {
+  return {
+    id: deliveryIdentifier,
+    pickupDodoId: entityPair.carrierDonorId,
+    pickupId: donor.establishmentId,
+    pickupFrom: pickupStart,
+    pickupTo: pickupEnd,
+    pickupNote: updateNoteWithPhoneNumbers(
+      donor.noteForDriver || "",
+      donor.phone,
+      recipient.phone,
+    ),
+    deliverId: recipient.establishmentId,
+    deliverAddress: `${recipient.street} ${recipient.houseNumber} ${recipient.city} ${recipient.postalCode}`,
+    deliverFrom: deliveryStart,
+    deliverTo: deliveryEnd,
+    deliverNote: updateNoteWithPhoneNumbers(
+      recipient.noteForDriver || "",
+      donor.phone,
+      recipient.phone,
+    ),
+    customerName: recipient.responsiblePerson,
+    customerPhone: recipient.phone,
+  };
+}
+
+/**
  * Build a box return DODO order object from entity data and pre-calculated time windows.
  * Pickup is from the recipient (box donor), delivery is back to the donor (original sender).
  * @param {EntityPair} entityPair - The entity pair


### PR DESCRIPTION
This pull request introduces a new Firestore trigger to automate the creation of DODO carrier orders for food deliveries, and refactors related code to support this feature. The main additions are a new `orderDeliveryService` function that reacts to delivery state changes and a utility for building food delivery orders.
**New Firestore trigger for DODO carrier order creation:**

* Added `orderDeliveryService`, a Firestore `onDocumentUpdated` trigger in `orderDeliveryServiceFunction.ts`, which creates a DODO carrier order when a `FOOD_DELIVERY` transitions to the `ACCEPTED` state and all required fields are present. This includes validation, entity lookup, idempotency checks, and error handling.

**Supporting utilities and refactoring:**

* Added `createFoodDeliveryOrder` in `dodoService.ts` to build a DODO order object for food deliveries, encapsulating the logic for populating all required fields from entities and time windows.
