### PR TITLE
ZOB-418 Add soft and force updates to web application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is a changelog for **ZachranObed** application.
 ## [2.1.0]
 ### Added
 - **ZOB-409** Add new FAQ section.
+- **ZOB-418** Add soft and force updates to web application.
 
 ### Fixed
 

--- a/lib/app/presentation/app_root.dart
+++ b/lib/app/presentation/app_root.dart
@@ -21,6 +21,7 @@ import 'package:zachranobed/common/presentation/utils/lifecycle_watcher.dart';
 import 'package:zachranobed/common/presentation/utils/ui_colors.dart';
 import 'package:zachranobed/common/presentation/utils/ui_text_styles.dart';
 import 'package:zachranobed/features/forceupdate/domain/usecase/check_if_upgrade_app_should_be_shown_usecase.dart';
+import 'package:zachranobed/features/forceupdate/presentation/web_soft_update_banner.dart';
 import 'package:zachranobed/features/offline/presentation/connectivity_wrapper.dart';
 import 'package:zachranobed/l10n/app_localizations.dart';
 
@@ -154,8 +155,10 @@ class _AppRootState extends State<AppRoot> with LifecycleWatcher {
               return const SizedBox();
             }
 
-            return ConnectivityWrapper(
-              child: child,
+            return SoftUpdateWebBanner(
+              child: ConnectivityWrapper(
+                child: child,
+              ),
             );
           },
         );

--- a/lib/common/data/dto/app_config_dto.dart
+++ b/lib/common/data/dto/app_config_dto.dart
@@ -10,8 +10,12 @@ part 'app_config_dto.g.dart';
 class AppConfigDto {
   final String minimumAppVersion;
 
+  @JsonKey(defaultValue: '0.0.0')
+  final String latestAppVersion;
+
   AppConfigDto({
     required this.minimumAppVersion,
+    required this.latestAppVersion,
   });
 
   factory AppConfigDto.fromJson(Map<String, dynamic> json) => _$AppConfigDtoFromJson(json);

--- a/lib/common/data/dto/app_config_dto.g.dart
+++ b/lib/common/data/dto/app_config_dto.g.dart
@@ -8,9 +8,11 @@ part of 'app_config_dto.dart';
 
 AppConfigDto _$AppConfigDtoFromJson(Map<String, dynamic> json) => AppConfigDto(
       minimumAppVersion: json['minimumAppVersion'] as String,
+      latestAppVersion: json['latestAppVersion'] as String? ?? '0.0.0',
     );
 
 Map<String, dynamic> _$AppConfigDtoToJson(AppConfigDto instance) =>
     <String, dynamic>{
       'minimumAppVersion': instance.minimumAppVersion,
+      'latestAppVersion': instance.latestAppVersion,
     };

--- a/lib/common/data/mapper/app_config_mapper.dart
+++ b/lib/common/data/mapper/app_config_mapper.dart
@@ -7,6 +7,7 @@ extension AppConfigMapper on AppConfigDto {
   AppConfig toDomain() {
     return AppConfig(
       minimumAppVersion: minimumAppVersion,
+      latestAppVersion: latestAppVersion,
     );
   }
 }

--- a/lib/common/domain/model/app_config.dart
+++ b/lib/common/domain/model/app_config.dart
@@ -10,5 +10,6 @@ part 'app_config.freezed.dart';
 abstract class AppConfig with _$AppConfig {
   const factory AppConfig({
     required String minimumAppVersion,
+    required String latestAppVersion,
   }) = $AppConfig;
 }

--- a/lib/common/domain/model/app_config.freezed.dart
+++ b/lib/common/domain/model/app_config.freezed.dart
@@ -16,6 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AppConfig {
   String get minimumAppVersion;
+  String get latestAppVersion;
 
   /// Create a copy of AppConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -30,15 +31,18 @@ mixin _$AppConfig {
         (other.runtimeType == runtimeType &&
             other is AppConfig &&
             (identical(other.minimumAppVersion, minimumAppVersion) ||
-                other.minimumAppVersion == minimumAppVersion));
+                other.minimumAppVersion == minimumAppVersion) &&
+            (identical(other.latestAppVersion, latestAppVersion) ||
+                other.latestAppVersion == latestAppVersion));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, minimumAppVersion);
+  int get hashCode =>
+      Object.hash(runtimeType, minimumAppVersion, latestAppVersion);
 
   @override
   String toString() {
-    return 'AppConfig(minimumAppVersion: $minimumAppVersion)';
+    return 'AppConfig(minimumAppVersion: $minimumAppVersion, latestAppVersion: $latestAppVersion)';
   }
 }
 
@@ -47,7 +51,7 @@ abstract mixin class $AppConfigCopyWith<$Res> {
   factory $AppConfigCopyWith(AppConfig value, $Res Function(AppConfig) _then) =
       _$AppConfigCopyWithImpl;
   @useResult
-  $Res call({String minimumAppVersion});
+  $Res call({String minimumAppVersion, String latestAppVersion});
 }
 
 /// @nodoc
@@ -63,11 +67,16 @@ class _$AppConfigCopyWithImpl<$Res> implements $AppConfigCopyWith<$Res> {
   @override
   $Res call({
     Object? minimumAppVersion = null,
+    Object? latestAppVersion = null,
   }) {
     return _then(_self.copyWith(
       minimumAppVersion: null == minimumAppVersion
           ? _self.minimumAppVersion
           : minimumAppVersion // ignore: cast_nullable_to_non_nullable
+              as String,
+      latestAppVersion: null == latestAppVersion
+          ? _self.latestAppVersion
+          : latestAppVersion // ignore: cast_nullable_to_non_nullable
               as String,
     ));
   }
@@ -76,10 +85,13 @@ class _$AppConfigCopyWithImpl<$Res> implements $AppConfigCopyWith<$Res> {
 /// @nodoc
 
 class $AppConfig implements AppConfig {
-  const $AppConfig({required this.minimumAppVersion});
+  const $AppConfig(
+      {required this.minimumAppVersion, required this.latestAppVersion});
 
   @override
   final String minimumAppVersion;
+  @override
+  final String latestAppVersion;
 
   /// Create a copy of AppConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -95,15 +107,18 @@ class $AppConfig implements AppConfig {
         (other.runtimeType == runtimeType &&
             other is $AppConfig &&
             (identical(other.minimumAppVersion, minimumAppVersion) ||
-                other.minimumAppVersion == minimumAppVersion));
+                other.minimumAppVersion == minimumAppVersion) &&
+            (identical(other.latestAppVersion, latestAppVersion) ||
+                other.latestAppVersion == latestAppVersion));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, minimumAppVersion);
+  int get hashCode =>
+      Object.hash(runtimeType, minimumAppVersion, latestAppVersion);
 
   @override
   String toString() {
-    return 'AppConfig(minimumAppVersion: $minimumAppVersion)';
+    return 'AppConfig(minimumAppVersion: $minimumAppVersion, latestAppVersion: $latestAppVersion)';
   }
 }
 
@@ -115,7 +130,7 @@ abstract mixin class $$AppConfigCopyWith<$Res>
       _$$AppConfigCopyWithImpl;
   @override
   @useResult
-  $Res call({String minimumAppVersion});
+  $Res call({String minimumAppVersion, String latestAppVersion});
 }
 
 /// @nodoc
@@ -131,11 +146,16 @@ class _$$AppConfigCopyWithImpl<$Res> implements $$AppConfigCopyWith<$Res> {
   @pragma('vm:prefer-inline')
   $Res call({
     Object? minimumAppVersion = null,
+    Object? latestAppVersion = null,
   }) {
     return _then($AppConfig(
       minimumAppVersion: null == minimumAppVersion
           ? _self.minimumAppVersion
           : minimumAppVersion // ignore: cast_nullable_to_non_nullable
+              as String,
+      latestAppVersion: null == latestAppVersion
+          ? _self.latestAppVersion
+          : latestAppVersion // ignore: cast_nullable_to_non_nullable
               as String,
     ));
   }

--- a/lib/common/presentation/utils/web_page_utils.dart
+++ b/lib/common/presentation/utils/web_page_utils.dart
@@ -1,2 +1,2 @@
-export 'web_page_utils_stub.dart'
-    if (dart.library.js_interop) 'web_page_utils_web.dart';
+export 'package:zachranobed/common/presentation/utils/web_page_utils_stub.dart'
+    if (dart.library.js_interop) 'package:zachranobed/common/presentation/utils/web_page_utils_web.dart';

--- a/lib/common/presentation/utils/web_page_utils.dart
+++ b/lib/common/presentation/utils/web_page_utils.dart
@@ -1,11 +1,2 @@
-import 'dart:js_interop';
-
-import 'package:flutter/foundation.dart';
-
-@JS('window.location.assign')
-external void _locationAssign(String url);
-
-/// Navigates to the home page, triggering a full reload. No-op on non-web platforms.
-void reloadWebPageToHome() {
-  if (kIsWeb) _locationAssign('/');
-}
+export 'web_page_utils_stub.dart'
+    if (dart.library.js_interop) 'web_page_utils_web.dart';

--- a/lib/common/presentation/utils/web_page_utils.dart
+++ b/lib/common/presentation/utils/web_page_utils.dart
@@ -1,0 +1,11 @@
+import 'dart:js_interop';
+
+import 'package:flutter/foundation.dart';
+
+@JS('window.location.assign')
+external void _locationAssign(String url);
+
+/// Navigates to the home page, triggering a full reload. No-op on non-web platforms.
+void reloadWebPageToHome() {
+  if (kIsWeb) _locationAssign('/');
+}

--- a/lib/common/presentation/utils/web_page_utils_stub.dart
+++ b/lib/common/presentation/utils/web_page_utils_stub.dart
@@ -1,0 +1,2 @@
+/// No-op on non-web platforms.
+void reloadWebPageToHome() {}

--- a/lib/common/presentation/utils/web_page_utils_web.dart
+++ b/lib/common/presentation/utils/web_page_utils_web.dart
@@ -1,0 +1,7 @@
+import 'dart:js_interop';
+
+@JS('window.location.assign')
+external void _locationAssign(String url);
+
+/// Navigates to the home page, triggering a full reload.
+void reloadWebPageToHome() => _locationAssign('/');

--- a/lib/common/presentation/utils/web_page_utils_web.dart
+++ b/lib/common/presentation/utils/web_page_utils_web.dart
@@ -1,7 +1,11 @@
 import 'dart:js_interop';
 
+@JS('document.baseURI')
+external String get _baseUri;
+
 @JS('window.location.assign')
 external void _locationAssign(String url);
 
-/// Navigates to the home page, triggering a full reload.
-void reloadWebPageToHome() => _locationAssign('/');
+/// Navigates to the app's base URL, triggering a full reload from the home route.
+/// Uses [document.baseURI] so it works at any deploy path.
+void reloadWebPageToHome() => _locationAssign(_baseUri);

--- a/lib/features/forceupdate/domain/di/force_update_dependency_container.dart
+++ b/lib/features/forceupdate/domain/di/force_update_dependency_container.dart
@@ -8,12 +8,12 @@ class ForceUpdateDependencyContainer {
 
   static void setup() {
     GetIt.I.registerFactory<CheckIfUpgradeAppShouldBeShownUseCase>(
-          () => CheckIfUpgradeAppShouldBeShownUseCase(
+      () => CheckIfUpgradeAppShouldBeShownUseCase(
         GetIt.I<AppConfigurationRepository>(),
       ),
     );
     GetIt.I.registerFactory<CheckWebSoftUpdateShouldBeShownUseCase>(
-          () => CheckWebSoftUpdateShouldBeShownUseCase(
+      () => CheckWebSoftUpdateShouldBeShownUseCase(
         GetIt.I<AppConfigurationRepository>(),
       ),
     );

--- a/lib/features/forceupdate/domain/di/force_update_dependency_container.dart
+++ b/lib/features/forceupdate/domain/di/force_update_dependency_container.dart
@@ -1,6 +1,7 @@
 import 'package:get_it/get_it.dart';
 import 'package:zachranobed/common/domain/repository/app_configuration_repository.dart';
 import 'package:zachranobed/features/forceupdate/domain/usecase/check_if_upgrade_app_should_be_shown_usecase.dart';
+import 'package:zachranobed/features/forceupdate/domain/usecase/check_web_soft_update_should_be_shown_usecase.dart';
 
 class ForceUpdateDependencyContainer {
   const ForceUpdateDependencyContainer._();
@@ -8,6 +9,11 @@ class ForceUpdateDependencyContainer {
   static void setup() {
     GetIt.I.registerFactory<CheckIfUpgradeAppShouldBeShownUseCase>(
           () => CheckIfUpgradeAppShouldBeShownUseCase(
+        GetIt.I<AppConfigurationRepository>(),
+      ),
+    );
+    GetIt.I.registerFactory<CheckWebSoftUpdateShouldBeShownUseCase>(
+          () => CheckWebSoftUpdateShouldBeShownUseCase(
         GetIt.I<AppConfigurationRepository>(),
       ),
     );

--- a/lib/features/forceupdate/domain/usecase/check_if_upgrade_app_should_be_shown_usecase.dart
+++ b/lib/features/forceupdate/domain/usecase/check_if_upgrade_app_should_be_shown_usecase.dart
@@ -12,7 +12,7 @@ class CheckIfUpgradeAppShouldBeShownUseCase {
 
   /// Fetches available application configuration.
   Future<bool> invoke() async {
-    if (!RunningPlatform.isMobile()) {
+    if (!RunningPlatform.isMobile() && !RunningPlatform.isWeb()) {
       return false;
     }
 

--- a/lib/features/forceupdate/domain/usecase/check_web_soft_update_should_be_shown_usecase.dart
+++ b/lib/features/forceupdate/domain/usecase/check_web_soft_update_should_be_shown_usecase.dart
@@ -1,0 +1,26 @@
+import 'package:pub_semver/pub_semver.dart';
+import 'package:zachranobed/common/data/utils/device_utils.dart';
+import 'package:zachranobed/common/domain/repository/app_configuration_repository.dart';
+import 'package:zachranobed/common/domain/utils/platform_utils.dart';
+import 'package:zachranobed/common/domain/utils/zo_logger.dart';
+
+/// Use case to check if a soft (optional) web update banner should be shown.
+///
+/// Returns `true` when running on web and the current version is behind the latest available version but still meets
+/// the minimum required version (the update is optional, not forced).
+class CheckWebSoftUpdateShouldBeShownUseCase {
+  final AppConfigurationRepository _repository;
+
+  CheckWebSoftUpdateShouldBeShownUseCase(this._repository);
+
+  Future<bool> invoke() async {
+    if (!RunningPlatform.isWeb()) return false;
+
+    final appConfig = await _repository.getAppConfig();
+
+    final current = Version.parse(await DeviceUtils.getAppSemanticVersion());
+    final latest = Version.parse(appConfig.latestAppVersion);
+    final minimum = Version.parse(appConfig.minimumAppVersion);
+    return current < latest && current >= minimum;
+  }
+}

--- a/lib/features/forceupdate/domain/usecase/check_web_soft_update_should_be_shown_usecase.dart
+++ b/lib/features/forceupdate/domain/usecase/check_web_soft_update_should_be_shown_usecase.dart
@@ -2,7 +2,6 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:zachranobed/common/data/utils/device_utils.dart';
 import 'package:zachranobed/common/domain/repository/app_configuration_repository.dart';
 import 'package:zachranobed/common/domain/utils/platform_utils.dart';
-import 'package:zachranobed/common/domain/utils/zo_logger.dart';
 
 /// Use case to check if a soft (optional) web update banner should be shown.
 ///

--- a/lib/features/forceupdate/presentation/force_update_screen.dart
+++ b/lib/features/forceupdate/presentation/force_update_screen.dart
@@ -1,14 +1,17 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:styled_text/styled_text.dart';
+import 'package:zachranobed/common/domain/utils/platform_utils.dart';
 import 'package:zachranobed/common/presentation/utils/build_context_extensions.dart';
 import 'package:zachranobed/common/presentation/utils/image_assets.dart';
 import 'package:zachranobed/common/presentation/utils/store_utils.dart';
-import 'package:zachranobed/common/presentation/widget/layout/adaptive_content.dart';
+import 'package:zachranobed/common/presentation/utils/web_page_utils.dart';
 import 'package:zachranobed/common/presentation/widget/button/ui_button_size.dart';
 import 'package:zachranobed/common/presentation/widget/button/ui_primary_button.dart';
-import 'package:zachranobed/common/presentation/widget/page/info_page.dart';
+import 'package:zachranobed/common/presentation/widget/layout/adaptive_content.dart';
 import 'package:zachranobed/common/presentation/widget/layout/screen_scaffold.dart';
+import 'package:zachranobed/common/presentation/widget/page/info_page.dart';
 
 /// A screen that notifies users when a mandatory app update is required.
 ///
@@ -30,32 +33,27 @@ class ForceUpdateScreen extends StatelessWidget {
           image: ImageAssets.imageForceUpdate,
           title: InfoPageContent.text(context.l10n.forceUpdateScreenTitle),
           description: InfoPageContent.widget(
-            Text.rich(
-              TextSpan(
-                children: [
-                  TextSpan(
-                    text: context.l10n.forceUpdateScreenDescriptionStart,
-                    style: context.textStyles.bodyLarge,
-                  ),
-                  TextSpan(
-                    text: context.l10n.applicationName,
-                    style: context.textStyles.bodyLarge.copyWith(fontWeight: FontWeight.bold),
-                  ),
-                  TextSpan(
-                    text: context.l10n.forceUpdateScreenDescriptionEnd,
-                    style: context.textStyles.bodyLarge,
-                  ),
-                ],
-              ),
+            StyledText(
+              text: context.l10n.forceUpdateScreenDescription,
+              style: context.textStyles.bodyLarge,
               textAlign: TextAlign.center,
+              tags: {
+                'b': StyledTextTag(
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              },
             ),
           ),
           actions: [
             UiPrimaryButton(
               size: UiButtonSize.medium(fullWidth: context.watch<AdaptiveLayoutConfig>().isMobile),
-              text: context.l10n.forceUpdateAction,
+              text: RunningPlatform.isWeb() ? context.l10n.forceUpdateWebAction : context.l10n.forceUpdateAction,
               onPressed: () async {
-                StoreUtils().openStore(context);
+                if (RunningPlatform.isWeb()) {
+                  reloadWebPageToHome();
+                } else {
+                  StoreUtils().openStore(context);
+                }
               },
             ),
           ],

--- a/lib/features/forceupdate/presentation/web_soft_update_banner.dart
+++ b/lib/features/forceupdate/presentation/web_soft_update_banner.dart
@@ -62,6 +62,7 @@ class _SoftUpdateWebBannerState extends State<SoftUpdateWebBanner> {
                       style: context.textStyles.titleMedium,
                     ),
                     Row(
+                      mainAxisSize: MainAxisSize.min,
                       spacing: 8,
                       children: [
                         UiTextButton(

--- a/lib/features/forceupdate/presentation/web_soft_update_banner.dart
+++ b/lib/features/forceupdate/presentation/web_soft_update_banner.dart
@@ -20,19 +20,24 @@ class SoftUpdateWebBanner extends StatefulWidget {
 }
 
 class _SoftUpdateWebBannerState extends State<SoftUpdateWebBanner> {
-  final _checkWebSoftUpdate = GetIt.I<CheckWebSoftUpdateShouldBeShownUseCase>();
+  late final CheckWebSoftUpdateShouldBeShownUseCase _checkWebSoftUpdate;
   bool _visible = false;
 
   @override
   void initState() {
     super.initState();
+    _checkWebSoftUpdate = GetIt.I<CheckWebSoftUpdateShouldBeShownUseCase>();
     WidgetsBinding.instance.addPostFrameCallback((_) => _check());
   }
 
   Future<void> _check() async {
-    final shouldShow = await _checkWebSoftUpdate.invoke();
-    if (shouldShow && mounted) {
-      setState(() => _visible = true);
+    try {
+      final shouldShow = await _checkWebSoftUpdate.invoke();
+      if (shouldShow && mounted) {
+        setState(() => _visible = true);
+      }
+    } catch (_) {
+      // Fail silently — banner is optional, errors must not affect the app.
     }
   }
 
@@ -45,31 +50,34 @@ class _SoftUpdateWebBannerState extends State<SoftUpdateWebBanner> {
           Positioned(
             right: 16,
             bottom: 16,
-            child: UiCard(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                spacing: 16,
-                children: [
-                  Text(
-                    context.l10n.softUpdateWebBannerMessage,
-                    style: context.textStyles.titleMedium,
-                  ),
-                  Row(
-                    spacing: 8,
-                    children: [
-                      UiTextButton(
-                        size: UiButtonSize.tiny(),
-                        text: context.l10n.softUpdateWebDismissAction,
-                        onPressed: () => setState(() => _visible = false),
-                      ),
-                      UiPrimaryButton(
-                        size: UiButtonSize.tiny(),
-                        text: context.l10n.softUpdateWebReloadAction,
-                        onPressed: reloadWebPageToHome,
-                      ),
-                    ],
-                  ),
-                ],
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 320),
+              child: UiCard(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  spacing: 16,
+                  children: [
+                    Text(
+                      context.l10n.softUpdateWebBannerMessage,
+                      style: context.textStyles.titleMedium,
+                    ),
+                    Row(
+                      spacing: 8,
+                      children: [
+                        UiTextButton(
+                          size: UiButtonSize.tiny(),
+                          text: context.l10n.softUpdateWebDismissAction,
+                          onPressed: () => setState(() => _visible = false),
+                        ),
+                        UiPrimaryButton(
+                          size: UiButtonSize.tiny(),
+                          text: context.l10n.softUpdateWebReloadAction,
+                          onPressed: reloadWebPageToHome,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/features/forceupdate/presentation/web_soft_update_banner.dart
+++ b/lib/features/forceupdate/presentation/web_soft_update_banner.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:zachranobed/common/presentation/utils/build_context_extensions.dart';
+import 'package:zachranobed/common/presentation/utils/web_page_utils.dart';
+import 'package:zachranobed/common/presentation/widget/button/ui_button_size.dart';
+import 'package:zachranobed/common/presentation/widget/button/ui_primary_button.dart';
+import 'package:zachranobed/common/presentation/widget/button/ui_text_button.dart';
+import 'package:zachranobed/common/presentation/widget/card/ui_card.dart';
+import 'package:zachranobed/features/forceupdate/domain/usecase/check_web_soft_update_should_be_shown_usecase.dart';
+
+/// Wraps [child] and overlays a dismissible soft-update card in the bottom-right corner when a newer
+/// (but non-mandatory) web version is available.
+class SoftUpdateWebBanner extends StatefulWidget {
+  final Widget child;
+
+  const SoftUpdateWebBanner({super.key, required this.child});
+
+  @override
+  State<SoftUpdateWebBanner> createState() => _SoftUpdateWebBannerState();
+}
+
+class _SoftUpdateWebBannerState extends State<SoftUpdateWebBanner> {
+  final _checkWebSoftUpdate = GetIt.I<CheckWebSoftUpdateShouldBeShownUseCase>();
+  bool _visible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _check());
+  }
+
+  Future<void> _check() async {
+    final shouldShow = await _checkWebSoftUpdate.invoke();
+    if (shouldShow && mounted) {
+      setState(() => _visible = true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        widget.child,
+        if (_visible)
+          Positioned(
+            right: 16,
+            bottom: 16,
+            child: UiCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                spacing: 16,
+                children: [
+                  Text(
+                    context.l10n.softUpdateWebBannerMessage,
+                    style: context.textStyles.titleMedium,
+                  ),
+                  Row(
+                    spacing: 8,
+                    children: [
+                      UiTextButton(
+                        size: UiButtonSize.tiny(),
+                        text: context.l10n.softUpdateWebDismissAction,
+                        onPressed: () => setState(() => _visible = false),
+                      ),
+                      UiPrimaryButton(
+                        size: UiButtonSize.tiny(),
+                        text: context.l10n.softUpdateWebReloadAction,
+                        onPressed: reloadWebPageToHome,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -269,7 +269,6 @@
     "forceUpdateScreenTitle": "Nová verze aplikace",
     "forceUpdateScreenDescription": "Tato verze aplikace již není podporována.\nPro další používání prosím aktualizujte aplikaci <b>Zachraň oběd</b> na nejnovější verzi.",
     "forceUpdateAction": "Aktualizovat aplikaci",
-
     "forceUpdateWebAction": "Aktualizovat stránku",
 
     "softUpdateWebBannerMessage": "Je dostupná nová verze aplikace.",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -267,9 +267,14 @@
     "activePairContactsCharityLabel": "(aktivní charita)",
 
     "forceUpdateScreenTitle": "Nová verze aplikace",
-    "forceUpdateScreenDescriptionStart": "Tato verze aplikace již není podporována.\nPro další používání prosím aktualizujte aplikaci ",
-    "forceUpdateScreenDescriptionEnd": " na nejnovější verzi.",
+    "forceUpdateScreenDescription": "Tato verze aplikace již není podporována.\nPro další používání prosím aktualizujte aplikaci <b>Zachraň oběd</b> na nejnovější verzi.",
     "forceUpdateAction": "Aktualizovat aplikaci",
+
+    "forceUpdateWebAction": "Aktualizovat stránku",
+
+    "softUpdateWebBannerMessage": "Je dostupná nová verze aplikace.",
+    "softUpdateWebReloadAction": "Aktualizovat",
+    "softUpdateWebDismissAction": "Později",
 
     "foodBoxesCheckupErrorMessage": "Při ukládání došlo k neočekávané chybě, zkuste akci provést znovu.",
     "foodBoxesCheckupSuccessMessage": "Děkujeme za spolupráci ",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1370,7 +1370,7 @@ packages:
     source: hosted
     version: "1.1.2"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dependencies:
   styled_text: ^9.0.0
   rxdart: ^0.28.0
   flutter_markdown: ^0.7.6
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Sumamry

Extends the existing update-check feature to the web platform:

- **Force update on web**: When the running version is below `minimumAppVersion`, the existing `ForceUpdateScreen` is shown. The CTA now reloads the page to `/` (instead of opening a store link).
- **Soft update banner**: A dismissible bottom-right card appears when the running version is behind `latestAppVersion` but still meets the minimum requirement. Users can dismiss it or reload to get the latest build.
- Adds `latestAppVersion` to `AppConfig` (with a safe default of `0.0.0` so existing Firebase configs without the field never trigger the banner).
- Migrates `ForceUpdateScreen` description from manual `Text.rich` spans to `styled_text` for cleaner markup.