### PR TITLE
ZOB-420 Add sending a device info to Firestore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a changelog for **ZachranObed** application.
 ### Added
 - **ZOB-409** Add new FAQ section.
 - **ZOB-418** Add soft and force updates to web application.
+- **ZOB-420** Add sending a device info to Firestore.
 
 ### Fixed
 - **ZOB-419** Fix logout related crash.

--- a/lib/app/presentation/app_root.dart
+++ b/lib/app/presentation/app_root.dart
@@ -104,8 +104,10 @@ class _AppRootState extends State<AppRoot> with LifecycleWatcher {
     }
   }
 
-  /// Performs the initial checks after the application starts.
-  /// 1. Update the device info (ID, app version, platform) — at most once per 24 hours.
+  /// Performs user-scoped checks on app start and whenever user data changes (e.g. login).
+  /// 1. Update the device info (ID, app version, platform) — once per app launch, and then at
+  ///    most once per 24 hours while the process stays alive (the timestamp is in-memory only
+  ///    and resets on logout or process restart).
   /// 2. Check if the app terms are accepted.
   /// 3. Check if the onboarding for UI changes should be shown.
   void _applicationStartCheckForUser(UserData user) async {
@@ -113,7 +115,7 @@ class _AppRootState extends State<AppRoot> with LifecycleWatcher {
     final lastUpdated = _deviceInfoLastUpdated;
     if (lastUpdated == null || now.difference(lastUpdated) >= const Duration(hours: 24)) {
       _deviceInfoLastUpdated = now;
-      _updateDeviceInfo.invoke(user.entityId);
+      await _updateDeviceInfo.invoke(user.entityId);
     }
 
     final status = await _getAppTermsStatus.invoke(user);

--- a/lib/app/presentation/app_root.dart
+++ b/lib/app/presentation/app_root.dart
@@ -13,6 +13,7 @@ import 'package:zachranobed/common/domain/usecase/notify_user_data_changed_useca
 import 'package:zachranobed/common/domain/usecase/observe_user_data_usecase.dart';
 import 'package:zachranobed/common/domain/usecase/remove_onboarding_for_ui_changes_flag_usecase.dart';
 import 'package:zachranobed/common/domain/usecase/should_show_onboarding_for_ui_changes_usecase.dart';
+import 'package:zachranobed/common/domain/usecase/update_device_info_usecase.dart';
 import 'package:zachranobed/common/domain/utils/platform_utils.dart';
 import 'package:zachranobed/common/presentation/notifiers/delivery_notifier.dart';
 import 'package:zachranobed/common/presentation/notifiers/user_notifier.dart';
@@ -42,6 +43,7 @@ class _AppRootState extends State<AppRoot> with LifecycleWatcher {
   final _getAppTermsStatus = GetIt.I<GetAppTermsStatusUseCase>();
   final _shouldShowOnboardingForUiChanges = GetIt.I<ShouldShowOnboardingForUiChangesUseCase>();
   final _removeOnboardingForUiChangesFlag = GetIt.I<RemoveOnboardingForUiChangesFlagUseCase>();
+  final _updateDeviceInfo = GetIt.I<UpdateDeviceInfoUseCase>();
 
   // Held as a field so it can be accessed from stream listeners (no context needed).
   final _userNotifier = UserNotifier();
@@ -49,6 +51,7 @@ class _AppRootState extends State<AppRoot> with LifecycleWatcher {
 
   StreamSubscription<void>? _userDataSubscription;
   UserData? _previousUserData;
+  DateTime? _deviceInfoLastUpdated;
 
   @override
   void initState() {
@@ -63,6 +66,7 @@ class _AppRootState extends State<AppRoot> with LifecycleWatcher {
       } else {
         _userNotifier.user = null;
         _deliveryNotifier.reset();
+        _deviceInfoLastUpdated = null;
         if (previous != null) {
           _appRouter.replaceAll([const LoginRoute()]);
         }
@@ -101,9 +105,17 @@ class _AppRootState extends State<AppRoot> with LifecycleWatcher {
   }
 
   /// Performs the initial checks after the application starts.
-  /// 1. Check if the app terms are accepted.
-  /// 2. Check if the onboarding for UI changes should be shown.
+  /// 1. Update the device info (ID, app version, platform) — at most once per 24 hours.
+  /// 2. Check if the app terms are accepted.
+  /// 3. Check if the onboarding for UI changes should be shown.
   void _applicationStartCheckForUser(UserData user) async {
+    final now = DateTime.now();
+    final lastUpdated = _deviceInfoLastUpdated;
+    if (lastUpdated == null || now.difference(lastUpdated) >= const Duration(hours: 24)) {
+      _deviceInfoLastUpdated = now;
+      _updateDeviceInfo.invoke(user.entityId);
+    }
+
     final status = await _getAppTermsStatus.invoke(user);
     if (status != AppTermsStatus.accepted) {
       _appRouter.replace(AppTermsRoute(hasNoAcceptedVersion: status == AppTermsStatus.notAccepted));

--- a/lib/common/data/repository/firebase_user_repository.dart
+++ b/lib/common/data/repository/firebase_user_repository.dart
@@ -68,4 +68,21 @@ class FirebaseUserRepository implements UserRepository {
   Future<void> removeOnboardingForUiChangesFlag(String entityId) {
     return _entityService.removeOnboardingForUiChangesFlag(entityId);
   }
+
+  @override
+  Future<void> updateDeviceInfo(
+    String entityId,
+    String appVersion,
+    String appVersionCode,
+    String platform,
+    String deviceId,
+  ) {
+    return _entityService.updateDeviceInfo(
+      entityId,
+      deviceId,
+      appVersion,
+      appVersionCode,
+      platform,
+    );
+  }
 }

--- a/lib/common/data/repository/firebase_user_repository.dart
+++ b/lib/common/data/repository/firebase_user_repository.dart
@@ -70,19 +70,19 @@ class FirebaseUserRepository implements UserRepository {
   }
 
   @override
-  Future<void> updateDeviceInfo(
-    String entityId,
-    String appVersion,
-    String appVersionCode,
-    String platform,
-    String deviceId,
-  ) {
+  Future<void> updateDeviceInfo({
+    required String entityId,
+    required String deviceId,
+    required String appVersion,
+    required String buildNumber,
+    required String platform,
+  }) {
     return _entityService.updateDeviceInfo(
-      entityId,
-      deviceId,
-      appVersion,
-      appVersionCode,
-      platform,
+      entityId: entityId,
+      deviceId: deviceId,
+      appVersion: appVersion,
+      buildNumber: buildNumber,
+      platform: platform,
     );
   }
 }

--- a/lib/common/data/repository/platform_device_repository.dart
+++ b/lib/common/data/repository/platform_device_repository.dart
@@ -13,6 +13,8 @@ class PlatformDeviceRepository implements DeviceRepository {
         return (await DeviceInfoPlugin().iosInfo).identifierForVendor;
       case RunningPlatform.android:
         return await const AndroidId().getId();
+      case RunningPlatform.web:
+        return 'web';
       default:
         return null;
     }
@@ -28,5 +30,11 @@ class PlatformDeviceRepository implements DeviceRepository {
   Future<String> getAppSemanticVersion() async {
     var info = await PackageInfo.fromPlatform();
     return info.version;
+  }
+
+  @override
+  Future<String> getAppBuildNumber() async {
+    var info = await PackageInfo.fromPlatform();
+    return info.buildNumber;
   }
 }

--- a/lib/common/data/service/entity_service.dart
+++ b/lib/common/data/service/entity_service.dart
@@ -72,6 +72,25 @@ class EntityService {
     );
   }
 
+  /// Stores device info (app version, build number, platform, last used timestamp)
+  /// for the given [deviceId] under the entity with ID [entityId].
+  Future<void> updateDeviceInfo(
+    String entityId,
+    String deviceId,
+    String appVersion,
+    String appVersionCode,
+    String platform,
+  ) {
+    return _collection.doc(entityId).update({
+      'devices.$deviceId': {
+        'appVersion': appVersion,
+        'appVersionCode': appVersionCode,
+        'platform': platform,
+        'lastUsed': FieldValue.serverTimestamp(),
+      },
+    });
+  }
+
   /// Checks if the onboarding for UI changes should be shown for the entity.
   ///
   /// Returns `true` if the `showOnboardingForUiChanges` flag is set to `true`,

--- a/lib/common/data/service/entity_service.dart
+++ b/lib/common/data/service/entity_service.dart
@@ -74,17 +74,17 @@ class EntityService {
 
   /// Stores device info (app version, build number, platform, last used timestamp)
   /// for the given [deviceId] under the entity with ID [entityId].
-  Future<void> updateDeviceInfo(
-    String entityId,
-    String deviceId,
-    String appVersion,
-    String appVersionCode,
-    String platform,
-  ) {
+  Future<void> updateDeviceInfo({
+    required String entityId,
+    required String deviceId,
+    required String appVersion,
+    required String buildNumber,
+    required String platform,
+  }) {
     return _collection.doc(entityId).update({
       'devices.$deviceId': {
         'appVersion': appVersion,
-        'appVersionCode': appVersionCode,
+        'buildNumber': buildNumber,
         'platform': platform,
         'lastUsed': FieldValue.serverTimestamp(),
       },

--- a/lib/common/di/common_dependency_container.dart
+++ b/lib/common/di/common_dependency_container.dart
@@ -18,6 +18,7 @@ import 'package:zachranobed/common/domain/repository/delivery_repository.dart';
 import 'package:zachranobed/common/domain/repository/device_repository.dart';
 import 'package:zachranobed/common/domain/repository/user_repository.dart';
 import 'package:zachranobed/common/domain/usecase/create_food_delivery_use_case.dart';
+import 'package:zachranobed/common/domain/usecase/get_app_build_number_usecase.dart';
 import 'package:zachranobed/common/domain/usecase/get_app_semantic_version_usecase.dart';
 import 'package:zachranobed/common/domain/usecase/get_app_terms_status_usecase.dart';
 import 'package:zachranobed/common/domain/usecase/get_app_version_usecase.dart';
@@ -29,6 +30,7 @@ import 'package:zachranobed/common/domain/usecase/observe_user_data_usecase.dart
 import 'package:zachranobed/common/domain/usecase/remove_onboarding_for_ui_changes_flag_usecase.dart';
 import 'package:zachranobed/common/domain/usecase/should_show_onboarding_for_ui_changes_usecase.dart';
 import 'package:zachranobed/common/domain/usecase/sign_out_usecase.dart';
+import 'package:zachranobed/common/domain/usecase/update_device_info_usecase.dart';
 import 'package:zachranobed/common/presentation/router/app_router.dart';
 
 class CommonDependencyContainer {
@@ -138,6 +140,17 @@ class CommonDependencyContainer {
     GetIt.I.registerFactory<GetAppVersionUseCase>(() => GetAppVersionUseCase(GetIt.I<DeviceRepository>()));
     GetIt.I.registerFactory<GetAppSemanticVersionUseCase>(
       () => GetAppSemanticVersionUseCase(GetIt.I<DeviceRepository>()),
+    );
+    GetIt.I.registerFactory<GetAppBuildNumberUseCase>(
+      () => GetAppBuildNumberUseCase(GetIt.I<DeviceRepository>()),
+    );
+    GetIt.I.registerFactory<UpdateDeviceInfoUseCase>(
+      () => UpdateDeviceInfoUseCase(
+        GetIt.I<UserRepository>(),
+        GetIt.I<GetDeviceIdUseCase>(),
+        GetIt.I<GetAppSemanticVersionUseCase>(),
+        GetIt.I<GetAppBuildNumberUseCase>(),
+      ),
     );
   }
 

--- a/lib/common/domain/repository/device_repository.dart
+++ b/lib/common/domain/repository/device_repository.dart
@@ -8,4 +8,7 @@ abstract class DeviceRepository {
 
   /// Returns the semantic app version (e.g. "1.0.0").
   Future<String> getAppSemanticVersion();
+
+  /// Returns the app build number (e.g. "42").
+  Future<String> getAppBuildNumber();
 }

--- a/lib/common/domain/repository/user_repository.dart
+++ b/lib/common/domain/repository/user_repository.dart
@@ -40,4 +40,13 @@ abstract class UserRepository {
 
   /// Removes the onboarding for UI changes flag from the entity document.
   Future<void> removeOnboardingForUiChangesFlag(String entityId);
+
+  /// Updates device info (app version, build number, platform) for the given entity.
+  Future<void> updateDeviceInfo(
+    String entityId,
+    String appVersion,
+    String appVersionCode,
+    String platform,
+    String deviceId,
+  );
 }

--- a/lib/common/domain/repository/user_repository.dart
+++ b/lib/common/domain/repository/user_repository.dart
@@ -42,11 +42,11 @@ abstract class UserRepository {
   Future<void> removeOnboardingForUiChangesFlag(String entityId);
 
   /// Updates device info (app version, build number, platform) for the given entity.
-  Future<void> updateDeviceInfo(
-    String entityId,
-    String appVersion,
-    String appVersionCode,
-    String platform,
-    String deviceId,
-  );
+  Future<void> updateDeviceInfo({
+    required String entityId,
+    required String deviceId,
+    required String appVersion,
+    required String buildNumber,
+    required String platform,
+  });
 }

--- a/lib/common/domain/usecase/get_app_build_number_usecase.dart
+++ b/lib/common/domain/usecase/get_app_build_number_usecase.dart
@@ -1,0 +1,10 @@
+import 'package:zachranobed/common/domain/repository/device_repository.dart';
+
+/// Use case to get the app build number (e.g. "42").
+class GetAppBuildNumberUseCase {
+  final DeviceRepository _repository;
+
+  GetAppBuildNumberUseCase(this._repository);
+
+  Future<String> invoke() => _repository.getAppBuildNumber();
+}

--- a/lib/common/domain/usecase/update_device_info_usecase.dart
+++ b/lib/common/domain/usecase/update_device_info_usecase.dart
@@ -28,15 +28,15 @@ class UpdateDeviceInfoUseCase {
       }
 
       final appVersion = await _getAppVersion.invoke();
-      final appVersionCode = await _getAppBuildNumber.invoke();
+      final buildNumber = await _getAppBuildNumber.invoke();
       final platform = RunningPlatform.current().name;
 
       await _userRepository.updateDeviceInfo(
-        entityId,
-        appVersion,
-        appVersionCode,
-        platform,
-        deviceId,
+        entityId: entityId,
+        deviceId: deviceId,
+        appVersion: appVersion,
+        buildNumber: buildNumber,
+        platform: platform,
       );
     } on Exception catch (e) {
       ZOLogger.logException(e, "Unable to update device info");

--- a/lib/common/domain/usecase/update_device_info_usecase.dart
+++ b/lib/common/domain/usecase/update_device_info_usecase.dart
@@ -1,0 +1,45 @@
+import 'package:zachranobed/common/domain/repository/user_repository.dart';
+import 'package:zachranobed/common/domain/usecase/get_app_build_number_usecase.dart';
+import 'package:zachranobed/common/domain/usecase/get_app_semantic_version_usecase.dart';
+import 'package:zachranobed/common/domain/usecase/get_device_id_usecase.dart';
+import 'package:zachranobed/common/domain/utils/platform_utils.dart';
+import 'package:zachranobed/common/domain/utils/zo_logger.dart';
+
+/// Use case to update the current device's info (ID, app version, build number, platform) in the entity document.
+class UpdateDeviceInfoUseCase {
+  final UserRepository _userRepository;
+  final GetDeviceIdUseCase _getDeviceId;
+  final GetAppSemanticVersionUseCase _getAppVersion;
+  final GetAppBuildNumberUseCase _getAppBuildNumber;
+
+  UpdateDeviceInfoUseCase(
+    this._userRepository,
+    this._getDeviceId,
+    this._getAppVersion,
+    this._getAppBuildNumber,
+  );
+
+  Future<void> invoke(String entityId) async {
+    try {
+      final deviceId = await _getDeviceId.invoke();
+      if (deviceId == null) {
+        ZOLogger.logMessage("Unable to update device info: device ID is null");
+        return;
+      }
+
+      final appVersion = await _getAppVersion.invoke();
+      final appVersionCode = await _getAppBuildNumber.invoke();
+      final platform = RunningPlatform.current().name;
+
+      await _userRepository.updateDeviceInfo(
+        entityId,
+        appVersion,
+        appVersionCode,
+        platform,
+        deviceId,
+      );
+    } on Exception catch (e) {
+      ZOLogger.logException(e, "Unable to update device info");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Writes per-device metadata to the entity document in Firestore whenever a user is active, so we can see which devices / app versions / platforms each entity uses.

- New `UpdateDeviceInfoUseCase` triggered from `AppRoot._applicationStartCheckForUser` — throttled in-memory to at most once per 24 h per app session.
- Written shape: `entities/{entityId}.devices.{deviceId} = { appVersion, appVersionCode, platform, lastUsed: serverTimestamp }`.
- Adds `'web'` as a recognized platform in `PlatformDeviceRepository.getDeviceId()` (previously `null`).
- Adds `GetAppBuildNumberUseCase` and extends `DeviceRepository` / `UserRepository` / `EntityService` with the new capability.