### PR TITLE
ZOB-412 Add prepared at date to meal tile

### DIFF
--- a/lib/features/food/presentation/widget/food_date_time_chips.dart
+++ b/lib/features/food/presentation/widget/food_date_time_chips.dart
@@ -159,7 +159,7 @@ class FoodDateTimeChips extends StatelessWidget {
       return const SizedBox();
     }
 
-    final dateTime = DateTimeUtils.formatDateTime(selectedDate.date, "d.M.yyyy HH:mm");
+    final dateTime = DateTimeUtils.formatDateTime(selectedDate.date, "d. M. yyyy HH:mm");
     final labelText = formatSelectedDate(dateTime);
     if (labelText == null) {
       return const SizedBox();

--- a/lib/features/food/presentation/widget/meal_tile_factory.dart
+++ b/lib/features/food/presentation/widget/meal_tile_factory.dart
@@ -37,9 +37,9 @@ class MealTileFactory {
     return switch (item.preparedAt) {
       null => null,
       FoodDateTimeSpecified(date: final date) =>
-        context.l10n.mealTileCoolingDateTemplate(DateTimeUtils.formatDateTime(date, "d. M. y")),
+        context.l10n.mealTilePreparedAtTemplate(DateTimeUtils.formatDateTime(date, "d. M. yyyy")),
       FoodDateTimeOnPackaging() =>
-        context.l10n.mealTileCoolingDateTemplate(context.l10n.foodDateTimeLabelOnPackaging.toLowerCase()),
+        context.l10n.mealTilePreparedAtTemplate(context.l10n.foodDateTimeLabelOnPackaging.toLowerCase()),
     };
   }
 
@@ -99,8 +99,7 @@ class MealTileFactory {
   /// Builds a date badge for the given [item].
   static UiMealBadge _buildDateBadge(BuildContext context, OfferedFood item) {
     final dateLabel = switch (item.consumeBy) {
-      FoodDateTimeSpecified(date: final date) =>
-        DateTimeUtils.formatDateTime(date, "d. M. y HH:mm"),
+      FoodDateTimeSpecified(date: final date) => DateTimeUtils.formatDateTime(date, "d. M. yyyy HH:mm"),
       FoodDateTimeOnPackaging() => context.l10n.foodDateTimeLabelOnPackaging,
     };
 

--- a/lib/features/food/presentation/widget/meal_tile_factory.dart
+++ b/lib/features/food/presentation/widget/meal_tile_factory.dart
@@ -23,6 +23,7 @@ class MealTileFactory {
   static Widget buildMealTile(BuildContext context, OfferedFood item) {
     return UiMealTile(
       title: item.dishName,
+      supportingText: _formatSupportingText(context, item),
       quantityLabel: _formatQuantity(context, item),
       badges: [
         _buildCategoryBadge(context, item),
@@ -30,6 +31,16 @@ class MealTileFactory {
         _buildDateBadge(context, item),
       ],
     );
+  }
+
+  static String? _formatSupportingText(BuildContext context, OfferedFood item) {
+    return switch (item.preparedAt) {
+      null => null,
+      FoodDateTimeSpecified(date: final date) =>
+        context.l10n.mealTileCoolingDateTemplate(DateTimeUtils.formatDateTime(date, "d. M. y")),
+      FoodDateTimeOnPackaging() =>
+        context.l10n.mealTileCoolingDateTemplate(context.l10n.foodDateTimeLabelOnPackaging.toLowerCase()),
+    };
   }
 
   /// Formats the quantity label for the given [item].
@@ -89,7 +100,7 @@ class MealTileFactory {
   static UiMealBadge _buildDateBadge(BuildContext context, OfferedFood item) {
     final dateLabel = switch (item.consumeBy) {
       FoodDateTimeSpecified(date: final date) =>
-        DateTimeUtils.formatDateTime(date, "d.M.y HH:mm"),
+        DateTimeUtils.formatDateTime(date, "d. M. y HH:mm"),
       FoodDateTimeOnPackaging() => context.l10n.foodDateTimeLabelOnPackaging,
     };
 

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -150,6 +150,15 @@
     "foodDateTimeLabelMinus1Day": "Včera",
     "foodDateTimeLabelMinus2Days": "-2 dny",
     "foodDateTimeLabelOnPackaging": "Viz obal",
+    "mealTileCoolingDateTemplate": "Datum zchlazení: {date}",
+    "@mealTileCoolingDateTemplate": {
+      "placeholders": {
+        "date": {
+          "type": "String",
+          "example": "2. 4. 2026"
+        }
+      }
+    },
     "foodDonationConfirmation": "Pokrm jste úspěšně darovali \u2764. Děkujeme, že pomáháte.",
     "shippingOrderConfirmation": "Vratku krabiček do jídelny jste úspěšně objednali \u2764. Děkujeme, že pomáháte.",
     "offerError": "Nabídku se \n nepodařilo odeslat. \n \u274c Zkuste to prosím \n znovu.",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -150,8 +150,8 @@
     "foodDateTimeLabelMinus1Day": "Včera",
     "foodDateTimeLabelMinus2Days": "-2 dny",
     "foodDateTimeLabelOnPackaging": "Viz obal",
-    "mealTileCoolingDateTemplate": "Datum zchlazení: {date}",
-    "@mealTileCoolingDateTemplate": {
+    "mealTilePreparedAtTemplate": "Datum zchlazení: {date}",
+    "@mealTilePreparedAtTemplate": {
       "placeholders": {
         "date": {
           "type": "String",


### PR DESCRIPTION
## Summary

Displays the `preparedAt` date on the `UiMealTile` as supporting text below the dish name.
When the date is specified it shows `"Datum zchlazení: d. M. y"`, when it is marked as
on-packaging it shows `"Datum zchlazení: viz obal"`, and when it is absent nothing is shown.

Also normalises date format separators in `FoodDateTimeChips` and the consume-by badge
from `"d.M.y"` to `"d. M. y"` for consistent Czech date rendering.