### PR TITLE
ZOB-426 Update node.js to 24, fix issues

### DIFF
--- a/.github/actions/artifacts-android/action.yml
+++ b/.github/actions/artifacts-android/action.yml
@@ -8,7 +8,7 @@ runs:
     # Uploads build artifacts generated during an Android build process. This allows easy access
     # and preservation of these build outputs.
     - name: Upload Android artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: android-artifacts
         path: |

--- a/.github/actions/artifacts-ios/action.yml
+++ b/.github/actions/artifacts-ios/action.yml
@@ -8,7 +8,7 @@ runs:
     # Uploads build artifacts generated during an iOS build process. This allows easy access
     # and preservation of these build outputs.
     - name: Upload iOS artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ios-artifacts
         path: |

--- a/.github/actions/publish-web/action.yml
+++ b/.github/actions/publish-web/action.yml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Checkout GitHub Pages repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository }}
         token: ${{ inputs.token }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,7 @@ runs:
   steps:
     # Sets up Java environment.
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/build_android_dev.yml
+++ b/.github/workflows/build_android_dev.yml
@@ -14,7 +14,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -38,11 +38,11 @@ jobs:
     steps:
       # Checkouts the repository.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Downloads Android related artifacts.
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       # Upload APK to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_android_dev.yml
+++ b/.github/workflows/build_android_dev.yml
@@ -43,6 +43,9 @@ jobs:
       # Downloads Android related artifacts.
       - name: Download artifacts
         uses: actions/download-artifact@v8
+        with:
+          name: android-artifacts
+          path: android-artifacts
 
       # Upload APK to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_android_prod.yml
+++ b/.github/workflows/build_android_prod.yml
@@ -63,6 +63,9 @@ jobs:
       # Downloads Android related artifacts.
       - name: Download artifacts
         uses: actions/download-artifact@v8
+        with:
+          name: android-artifacts
+          path: android-artifacts
 
       # Upload APK to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_android_prod.yml
+++ b/.github/workflows/build_android_prod.yml
@@ -14,7 +14,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -58,11 +58,11 @@ jobs:
     steps:
       # Checkouts the repository.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Downloads Android related artifacts.
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       # Upload APK to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_android_stage.yml
+++ b/.github/workflows/build_android_stage.yml
@@ -14,7 +14,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -38,11 +38,11 @@ jobs:
     steps:
       # Checkouts the repository.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Downloads Android related artifacts.
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       # Upload APK to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_android_stage.yml
+++ b/.github/workflows/build_android_stage.yml
@@ -43,6 +43,9 @@ jobs:
       # Downloads Android related artifacts.
       - name: Download artifacts
         uses: actions/download-artifact@v8
+        with:
+          name: android-artifacts
+          path: android-artifacts
 
       # Upload APK to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_ios_dev.yml
+++ b/.github/workflows/build_ios_dev.yml
@@ -9,4 +9,4 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6

--- a/.github/workflows/build_ios_prod.yml
+++ b/.github/workflows/build_ios_prod.yml
@@ -51,6 +51,9 @@ jobs:
       # Downloads iOS related artifacts.
       - name: Download artifacts
         uses: actions/download-artifact@v8
+        with:
+          name: ios-artifacts
+          path: ios-artifacts
 
       # Upload IPA to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_ios_prod.yml
+++ b/.github/workflows/build_ios_prod.yml
@@ -14,7 +14,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -46,11 +46,11 @@ jobs:
     steps:
       # Checkouts the repository.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Downloads iOS related artifacts.
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       # Upload IPA to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_ios_rc.yml
+++ b/.github/workflows/build_ios_rc.yml
@@ -51,6 +51,9 @@ jobs:
       # Downloads iOS related artifacts.
       - name: Download artifacts
         uses: actions/download-artifact@v8
+        with:
+          name: ios-artifacts
+          path: ios-artifacts
 
       # Upload IPA to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_ios_rc.yml
+++ b/.github/workflows/build_ios_rc.yml
@@ -14,7 +14,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -46,11 +46,11 @@ jobs:
     steps:
       # Checkouts the repository.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Downloads iOS related artifacts.
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       # Upload IPA to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_ios_stage.yml
+++ b/.github/workflows/build_ios_stage.yml
@@ -51,6 +51,9 @@ jobs:
       # Downloads iOS related artifacts.
       - name: Download artifacts
         uses: actions/download-artifact@v8
+        with:
+          name: ios-artifacts
+          path: ios-artifacts
 
       # Upload IPA to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_ios_stage.yml
+++ b/.github/workflows/build_ios_stage.yml
@@ -14,7 +14,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -46,11 +46,11 @@ jobs:
     steps:
       # Checkouts the repository.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Downloads iOS related artifacts.
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       # Upload IPA to the Firebase and distribute it with latest release notes.
       - name: Distribute to Firebase App Distribution

--- a/.github/workflows/build_web_dev.yml
+++ b/.github/workflows/build_web_dev.yml
@@ -11,7 +11,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build_web_prod.yml
+++ b/.github/workflows/build_web_prod.yml
@@ -11,7 +11,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build_web_stage.yml
+++ b/.github/workflows/build_web_stage.yml
@@ -11,7 +11,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create_report.yml
+++ b/.github/workflows/create_report.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'  # Specify the Node.js version you need
+          node-version: '24'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/create_report.yml
+++ b/.github/workflows/create_report.yml
@@ -21,10 +21,6 @@ jobs:
   modify-firestore:
     runs-on: ubuntu-latest
     timeout-minutes: 15  # Set a timeout of 15 minutes
-    env:
-      # szenius/set-timezone has no Node 24 release; force it onto Node 24 until a newer version of the action exists.
-      # See: https://github.com/szenius/set-timezone/issues/30
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Set previous month as TARGET_PERIOD for scheduled run
@@ -75,9 +71,7 @@ jobs:
           done
 
       - name: Set timezone
-        uses: szenius/set-timezone@v2.0
-        with:
-          timezoneLinux: "Europe/Prague"
+        run: sudo timedatectl set-timezone Europe/Prague
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/create_report.yml
+++ b/.github/workflows/create_report.yml
@@ -21,6 +21,10 @@ jobs:
   modify-firestore:
     runs-on: ubuntu-latest
     timeout-minutes: 15  # Set a timeout of 15 minutes
+    env:
+      # szenius/set-timezone has no Node 24 release; force it onto Node 24 until a newer version of the action exists.
+      # See: https://github.com/szenius/set-timezone/issues/30
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Set previous month as TARGET_PERIOD for scheduled run
@@ -76,10 +80,10 @@ jobs:
           timezoneLinux: "Europe/Prague"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
       # Checkouts the repository with entire commit history, which is needed to calculate the
       # correct build version code in 'Setup environment' step.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,7 @@ Interactive component gallery available at `lib/features/debug/components_screen
 
 ## Firebase Cloud Functions
 
-The `functions/` directory contains TypeScript Cloud Functions deployed on Node.js v20.
+The `functions/` directory contains TypeScript Cloud Functions deployed on Node.js v24.
 
 ```bash
 # Navigate to functions directory

--- a/firebase.json
+++ b/firebase.json
@@ -19,7 +19,7 @@
     "functions": {
       "port": 5001,
       "source": "functions",
-      "runtime": "nodejs20"
+      "runtime": "nodejs24"
     },
     "firestore": {
       "port": 8080

--- a/functions/.specify/memory/constitution.md
+++ b/functions/.specify/memory/constitution.md
@@ -75,7 +75,7 @@ src/
 Development MUST use the specified toolchain versions and configurations to ensure consistency across environments.
 
 **Required Stack**:
-- **Node.js**: v20 (as specified in `engines.node`)
+- **Node.js**: v24 (as specified in `engines.node`)
 - **TypeScript**: ^5.7.3 with ES2017 target, CommonJS module format
 - **Firebase Admin SDK**: ^13.6.0
 - **Firebase Functions**: v2 API (^6.4.0) - NOT v1 API

--- a/functions/CLAUDE.md
+++ b/functions/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Firebase Cloud Functions for Zachraň oběd (Save Lunch) - a backend service handling automated notifications, scheduled tasks, and business logic for the food redistribution platform.
 
-- Node.js: v20
+- Node.js: v24
 - TypeScript: ^5.7.3
 - Firebase Functions: v2 (^6.4.0)
 - Firebase Admin SDK: ^13.6.0

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -923,9 +923,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1852,6 +1852,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2033,7 +2046,8 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
@@ -2041,9 +2055,10 @@
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
@@ -2051,12 +2066,12 @@
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -2065,9 +2080,10 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
@@ -2080,9 +2096,10 @@
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -2102,9 +2119,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3114,9 +3131,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3358,9 +3375,9 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5202,12 +5219,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5217,15 +5234,6 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
-      }
-    },
-    "node_modules/express-rate-limit/node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -5306,9 +5314,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -5318,12 +5326,13 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -5333,13 +5342,14 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -5349,9 +5359,11 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5484,9 +5496,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -5496,9 +5508,7 @@
         "fast-deep-equal": "^3.1.1",
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
-        "uuid": "^11.0.2"
+        "jwks-rsa": "^3.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -5587,19 +5597,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/firebase-functions": {
@@ -6452,9 +6449,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6665,13 +6662,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -7287,11 +7281,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
-    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -7562,9 +7551,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash._objecttypes": {
@@ -7686,9 +7675,10 @@
       }
     },
     "node_modules/long": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
-      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng=="
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -8300,15 +8290,6 @@
         }
       }
     },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/node-gyp": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
@@ -8823,9 +8804,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -9130,24 +9111,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -10015,11 +9996,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -10064,11 +10046,6 @@
       "engines": {
         "node": ">= 10.x"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/sql-formatter": {
       "version": "15.4.10",
@@ -10302,9 +10279,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -11489,6 +11466,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -26,7 +26,7 @@
         "typescript-eslint": "^8.24.1"
       },
       "engines": {
-        "node": "20"
+        "node": "24"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "20"
+    "node": "24"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/functions/src/config/firebase.ts
+++ b/functions/src/config/firebase.ts
@@ -21,8 +21,6 @@ setGlobalOptions({
   serviceAccount: currentServiceAccount,
 });
 
-export const githubToken = defineString("GITHUB_TOKEN");
-
 // Cloud Tasks config params
 export const cloudTasksQueue = defineString("CLOUD_TASKS_QUEUE", { default: "delivery-state-transitions" });
 export const cloudTasksLocation = defineString("CLOUD_TASKS_LOCATION", { default: "europe-west1" });


### PR DESCRIPTION
## Summary
Bumps the Cloud Functions runtime from Node.js 20 to 24, refreshes all GitHub Actions to current major versions, and cleans up dead config / dependencies that accumulated along the way.

## Changes

### Runtime
- `functions` engines + `firebase.json` runtime: `nodejs20` → `nodejs24`
- `create_report.yml` workflow Node setup: `20` → `24`
- Docs updated to reflect v24

### GitHub Actions version bumps
- `actions/checkout`: v4 → v6
- `actions/upload-artifact`: v4 → v7
- `actions/download-artifact`: v4 → v8 (now requires explicit `name` and `path` — added in all Android/iOS distribute jobs)
- `actions/setup-java`: v4 → v5
- `actions/setup-node`: v4 → v6

### Workflow simplification
- `create_report.yml`: replaced the `szenius/set-timezone@v2.0` third-party action with the native `sudo timedatectl set-timezone Europe/Prague` command

### Cleanup
- Removed unused `githubToken = defineString("GITHUB_TOKEN")` from `functions/src/config/firebase.ts` (no callers)
- `functions/package-lock.json` regenerated against newer transitive dependencies (drops `node-forge`, `jsbn`, `sprintf-js`, inner `uuid` copy; bumps `firebase-admin`, `protobufjs`, `ip-address`, `hono`, etc.)
